### PR TITLE
[codex] Revert stop workflow to hour-based gate

### DIFF
--- a/.github/workflows/start_market_data_notification.yml
+++ b/.github/workflows/start_market_data_notification.yml
@@ -6,7 +6,7 @@ permissions:
   contents: read
 on:
   schedule:
-    # run time is usually delayed by up to 30mins
+    # run time can be delayed by up to 30mins
     # 0 = sunday, 6 = saturday
     - cron: '05 12,13 * * 0-6' # weekdays
     - cron: '05 19,20 * * 0-6' # weekdays

--- a/.github/workflows/stop_market_data_notification.yml
+++ b/.github/workflows/stop_market_data_notification.yml
@@ -31,8 +31,8 @@ env:
   # Market open at 9.30am and close at 4pm local time.
   # Scheduled runs use paired UTC cron entries for DST; gate by local hour
   # so delayed runs still proceed while the DST counterpart hour is skipped.
-  MORNING_STOP_LOCAL_HOUR: 9
-  CLOSE_STOP_LOCAL_HOUR: 16
+  AFTER_MARKET_OPEN_STOP_LOCAL_HOUR: 9
+  AFTER_MARKET_CLOSE_STOP_LOCAL_HOUR: 16
 jobs:
   check_timezone:
     runs-on: ubuntu-latest
@@ -60,9 +60,9 @@ jobs:
             exit 0
           fi
 
-          echo "current_local_time: $current_local_time, current_local_hour: $current_local_hour, MORNING_STOP_LOCAL_HOUR: $MORNING_STOP_LOCAL_HOUR, CLOSE_STOP_LOCAL_HOUR: $CLOSE_STOP_LOCAL_HOUR"
+          echo "current_local_time: $current_local_time, current_local_hour: $current_local_hour, AFTER_MARKET_OPEN_STOP_LOCAL_HOUR: $AFTER_MARKET_OPEN_STOP_LOCAL_HOUR, AFTER_MARKET_CLOSE_STOP_LOCAL_HOUR: $AFTER_MARKET_CLOSE_STOP_LOCAL_HOUR"
 
-          if [ "$current_local_hour" -eq "$MORNING_STOP_LOCAL_HOUR" ] || [ "$current_local_hour" -eq "$CLOSE_STOP_LOCAL_HOUR" ]
+          if [ "$current_local_hour" -eq "$AFTER_MARKET_OPEN_STOP_LOCAL_HOUR" ] || [ "$current_local_hour" -eq "$AFTER_MARKET_CLOSE_STOP_LOCAL_HOUR" ]
           then
             echo "should_proceed=true" >> "$GITHUB_OUTPUT"
             echo "skip_reason=inside stop hour" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/stop_market_data_notification.yml
+++ b/.github/workflows/stop_market_data_notification.yml
@@ -29,11 +29,10 @@ on:
 env:
   TZ: America/New_York
   # Market open at 9.30am and close at 4pm local time.
-  # Scheduled runs use paired UTC cron entries for DST and can be delayed by up to 30 minutes.
-  MORNING_STOP_WINDOW_START_HHMM: 0915
-  MORNING_STOP_WINDOW_END_HHMM: 0945
-  CLOSE_STOP_WINDOW_START_HHMM: 1635
-  CLOSE_STOP_WINDOW_END_HHMM: 1705
+  # Scheduled runs use paired UTC cron entries for DST; gate by local hour
+  # so delayed runs still proceed while the DST counterpart hour is skipped.
+  MORNING_STOP_LOCAL_HOUR: 9
+  CLOSE_STOP_LOCAL_HOUR: 16
 jobs:
   check_timezone:
     runs-on: ubuntu-latest
@@ -49,6 +48,8 @@ jobs:
         run: |
           current_local_time=$(TZ=$TZ date +%H%M)
           current_local_time=$((10#$current_local_time))
+          current_local_hour=$(TZ=$TZ date +%H)
+          current_local_hour=$((10#$current_local_hour))
 
           if [ "$IGNORE_TIMEZONE" = "true" ]
           then
@@ -59,21 +60,15 @@ jobs:
             exit 0
           fi
 
-          echo "current_local_time: $current_local_time, MORNING_STOP_WINDOW: $MORNING_STOP_WINDOW_START_HHMM-$MORNING_STOP_WINDOW_END_HHMM, CLOSE_STOP_WINDOW: $CLOSE_STOP_WINDOW_START_HHMM-$CLOSE_STOP_WINDOW_END_HHMM"
+          echo "current_local_time: $current_local_time, current_local_hour: $current_local_hour, MORNING_STOP_LOCAL_HOUR: $MORNING_STOP_LOCAL_HOUR, CLOSE_STOP_LOCAL_HOUR: $CLOSE_STOP_LOCAL_HOUR"
 
-          if {
-            [ "$current_local_time" -ge $((10#$MORNING_STOP_WINDOW_START_HHMM)) ] &&
-            [ "$current_local_time" -le $((10#$MORNING_STOP_WINDOW_END_HHMM)) ];
-          } || {
-            [ "$current_local_time" -ge $((10#$CLOSE_STOP_WINDOW_START_HHMM)) ] &&
-            [ "$current_local_time" -le $((10#$CLOSE_STOP_WINDOW_END_HHMM)) ];
-          }
+          if [ "$current_local_hour" -eq "$MORNING_STOP_LOCAL_HOUR" ] || [ "$current_local_hour" -eq "$CLOSE_STOP_LOCAL_HOUR" ]
           then
             echo "should_proceed=true" >> "$GITHUB_OUTPUT"
-            echo "skip_reason=inside stop window" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=inside stop hour" >> "$GITHUB_OUTPUT"
           else
             echo "should_proceed=false" >> "$GITHUB_OUTPUT"
-            echo "skip_reason=outside local stop windows 09:15-09:45 and 16:35-17:05 America/New_York" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=outside local stop hours 09 and 16 America/New_York" >> "$GITHUB_OUTPUT"
           fi
 
           echo "current_local_time=$current_local_time" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/stop_market_data_notification.yml
+++ b/.github/workflows/stop_market_data_notification.yml
@@ -6,7 +6,7 @@ permissions:
   contents: read
 on:
   schedule:
-    # run time is usually delayed by up to 30mins
+    # run time can be delayed by up to 30mins
     # 0 = sunday, 6 = saturday
     - cron: '15 13,14 * * 0-6' # weekdays
     - cron: '35 20,21 * * 0-6' # weekdays


### PR DESCRIPTION
## Summary
Revert the stop workflow time gate from strict minute windows back to local-hour gating.

## Why
The stop workflow was tightened in `3cdc2ef` to only proceed inside `09:15-09:45` or `16:35-17:05` America/New_York. In practice, GitHub scheduled workflows can start late enough to miss those windows. A real run at `09:53` EDT was skipped even though it should still have stopped the instance.

Hour-based gating keeps the DST paired cron strategy intact:
- delayed runs within local hour `09` or `16` still proceed
- the DST counterpart hours like `08` or `10` still skip

## Impact
This makes delayed scheduled stop runs more tolerant without allowing the wrong DST counterpart run to execute.

## Validation
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/stop_market_data_notification.yml')); print('yaml ok')"`
- `git diff --check`
