### PR TITLE
[codex] Align start and stop workflow time gating

### DIFF
--- a/.github/workflows/start_market_data_notification.yml
+++ b/.github/workflows/start_market_data_notification.yml
@@ -6,10 +6,10 @@ permissions:
   contents: read
 on:
   schedule:
-    # run time is usually delayed by up to 30mins
+    # run time can be delayed by up to 30mins
     # 0 = sunday, 6 = saturday
-    - cron: '05 12,13 * * 0-6' # weekdays
-    - cron: '05 19,20 * * 0-6' # weekdays
+    - cron: '05 12,13 * * 0-6' # every day
+    - cron: '05 19,20 * * 0-6' # every day
   workflow_dispatch:
     inputs:
       logLevel:
@@ -29,11 +29,10 @@ on:
 env:
   TZ: America/New_York
   # Market open at 9.30am and close at 4pm local time.
-  # Scheduled runs use paired UTC cron entries for DST and can be delayed by up to 30 minutes.
-  MORNING_START_WINDOW_START_HHMM: 0830
-  MORNING_START_WINDOW_END_HHMM: 0930
-  CLOSE_START_WINDOW_START_HHMM: 1545
-  CLOSE_START_WINDOW_END_HHMM: 1645
+  # Scheduled runs use paired UTC cron entries for DST; gate by local hour
+  # so delayed runs still proceed while the DST counterpart hour is skipped.
+  BEFORE_MARKET_OPEN_START_LOCAL_HOUR: 8
+  BEFORE_MARKET_CLOSE_START_LOCAL_HOUR: 15
 jobs:
   check_timezone:
     runs-on: ubuntu-latest
@@ -49,6 +48,8 @@ jobs:
         run: |
           current_local_time=$(TZ=$TZ date +%H%M)
           current_local_time=$((10#$current_local_time))
+          current_local_hour=$(TZ=$TZ date +%H)
+          current_local_hour=$((10#$current_local_hour))
 
           if [ "$IGNORE_TIMEZONE" = "true" ]
           then
@@ -59,21 +60,15 @@ jobs:
             exit 0
           fi
 
-          echo "current_local_time: $current_local_time, MORNING_START_WINDOW: $MORNING_START_WINDOW_START_HHMM-$MORNING_START_WINDOW_END_HHMM, CLOSE_START_WINDOW: $CLOSE_START_WINDOW_START_HHMM-$CLOSE_START_WINDOW_END_HHMM"
+          echo "current_local_time: $current_local_time, current_local_hour: $current_local_hour, BEFORE_MARKET_OPEN_START_LOCAL_HOUR: $BEFORE_MARKET_OPEN_START_LOCAL_HOUR, BEFORE_MARKET_CLOSE_START_LOCAL_HOUR: $BEFORE_MARKET_CLOSE_START_LOCAL_HOUR"
 
-          if {
-            [ "$current_local_time" -ge $((10#$MORNING_START_WINDOW_START_HHMM)) ] &&
-            [ "$current_local_time" -le $((10#$MORNING_START_WINDOW_END_HHMM)) ];
-          } || {
-            [ "$current_local_time" -ge $((10#$CLOSE_START_WINDOW_START_HHMM)) ] &&
-            [ "$current_local_time" -le $((10#$CLOSE_START_WINDOW_END_HHMM)) ];
-          }
+          if [ "$current_local_hour" -eq "$BEFORE_MARKET_OPEN_START_LOCAL_HOUR" ] || [ "$current_local_hour" -eq "$BEFORE_MARKET_CLOSE_START_LOCAL_HOUR" ]
           then
             echo "should_proceed=true" >> "$GITHUB_OUTPUT"
-            echo "skip_reason=inside start window" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=inside start hour" >> "$GITHUB_OUTPUT"
           else
             echo "should_proceed=false" >> "$GITHUB_OUTPUT"
-            echo "skip_reason=outside local start windows 08:30-09:30 and 15:45-16:45 America/New_York" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=outside local start hours 08 and 15 America/New_York" >> "$GITHUB_OUTPUT"
           fi
           echo "current_local_time=$current_local_time" >> "$GITHUB_OUTPUT"
   skip_outside_start_window:

--- a/.github/workflows/stop_market_data_notification.yml
+++ b/.github/workflows/stop_market_data_notification.yml
@@ -6,10 +6,10 @@ permissions:
   contents: read
 on:
   schedule:
-    # run time is usually delayed by up to 30mins
+    # run time can be delayed by up to 30mins
     # 0 = sunday, 6 = saturday
-    - cron: '15 13,14 * * 0-6' # weekdays
-    - cron: '35 20,21 * * 0-6' # weekdays
+    - cron: '15 13,14 * * 0-6' # every day
+    - cron: '35 20,21 * * 0-6' # every day
   workflow_dispatch:
     inputs:
       logLevel:
@@ -29,11 +29,10 @@ on:
 env:
   TZ: America/New_York
   # Market open at 9.30am and close at 4pm local time.
-  # Scheduled runs use paired UTC cron entries for DST and can be delayed by up to 30 minutes.
-  MORNING_STOP_WINDOW_START_HHMM: 0915
-  MORNING_STOP_WINDOW_END_HHMM: 0945
-  CLOSE_STOP_WINDOW_START_HHMM: 1635
-  CLOSE_STOP_WINDOW_END_HHMM: 1705
+  # Scheduled runs use paired UTC cron entries for DST; gate by local hour
+  # so delayed runs still proceed while the DST counterpart hour is skipped.
+  AFTER_MARKET_OPEN_STOP_LOCAL_HOUR: 9
+  AFTER_MARKET_CLOSE_STOP_LOCAL_HOUR: 16
 jobs:
   check_timezone:
     runs-on: ubuntu-latest
@@ -49,6 +48,8 @@ jobs:
         run: |
           current_local_time=$(TZ=$TZ date +%H%M)
           current_local_time=$((10#$current_local_time))
+          current_local_hour=$(TZ=$TZ date +%H)
+          current_local_hour=$((10#$current_local_hour))
 
           if [ "$IGNORE_TIMEZONE" = "true" ]
           then
@@ -59,21 +60,15 @@ jobs:
             exit 0
           fi
 
-          echo "current_local_time: $current_local_time, MORNING_STOP_WINDOW: $MORNING_STOP_WINDOW_START_HHMM-$MORNING_STOP_WINDOW_END_HHMM, CLOSE_STOP_WINDOW: $CLOSE_STOP_WINDOW_START_HHMM-$CLOSE_STOP_WINDOW_END_HHMM"
+          echo "current_local_time: $current_local_time, current_local_hour: $current_local_hour, AFTER_MARKET_OPEN_STOP_LOCAL_HOUR: $AFTER_MARKET_OPEN_STOP_LOCAL_HOUR, AFTER_MARKET_CLOSE_STOP_LOCAL_HOUR: $AFTER_MARKET_CLOSE_STOP_LOCAL_HOUR"
 
-          if {
-            [ "$current_local_time" -ge $((10#$MORNING_STOP_WINDOW_START_HHMM)) ] &&
-            [ "$current_local_time" -le $((10#$MORNING_STOP_WINDOW_END_HHMM)) ];
-          } || {
-            [ "$current_local_time" -ge $((10#$CLOSE_STOP_WINDOW_START_HHMM)) ] &&
-            [ "$current_local_time" -le $((10#$CLOSE_STOP_WINDOW_END_HHMM)) ];
-          }
+          if [ "$current_local_hour" -eq "$AFTER_MARKET_OPEN_STOP_LOCAL_HOUR" ] || [ "$current_local_hour" -eq "$AFTER_MARKET_CLOSE_STOP_LOCAL_HOUR" ]
           then
             echo "should_proceed=true" >> "$GITHUB_OUTPUT"
-            echo "skip_reason=inside stop window" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=inside stop hour" >> "$GITHUB_OUTPUT"
           else
             echo "should_proceed=false" >> "$GITHUB_OUTPUT"
-            echo "skip_reason=outside local stop windows 09:15-09:45 and 16:35-17:05 America/New_York" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=outside local stop hours 09 and 16 America/New_York" >> "$GITHUB_OUTPUT"
           fi
 
           echo "current_local_time=$current_local_time" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What changed
- change the start workflow from HHMM window gating to local-hour gating so it matches the stop workflow pattern
- keep both start cron entries aligned at minute `05`
- update workflow comments so `0-6` is described as every day instead of weekdays

## Why
- the stop workflow had already moved to hour-only gating while the start workflow still used HHMM windows
- this makes the start and stop behavior consistent and keeps the accepted start runs at about `08:05 ET` and `15:05 ET`
- that preserves buffer before the `09:00 ET` backend jobs and the reported `16:01 ET` TradingView webhook window

## Validation
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('market-data-notification-infra/.github/workflows/start_market_data_notification.yml').read_text()); yaml.safe_load(pathlib.Path('market-data-notification-infra/.github/workflows/stop_market_data_notification.yml').read_text())"`
- `git -C market-data-notification-infra diff --check`