### PR TITLE
[codex] Add Let's Encrypt backup phase 1 infra flow

### DIFF
--- a/.github/workflows/start_market_data_notification.yml
+++ b/.github/workflows/start_market_data_notification.yml
@@ -131,6 +131,7 @@ jobs:
       AWS_REGION: ${{ secrets.AWS_REGION }}
       HOST_NAME: ${{ secrets.HOST_NAME }}
       INSTANCE_TAG_NAME: ${{ vars.INSTANCE_TAG_NAME }}
+      ROUTE53_HOSTED_ZONE_ID: ${{ vars.ROUTE53_HOSTED_ZONE_ID }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up ansible

--- a/.github/workflows/start_market_data_notification.yml
+++ b/.github/workflows/start_market_data_notification.yml
@@ -127,6 +127,7 @@ jobs:
       DOMAIN: ${{ secrets.DOMAIN }}
       SSH_USER: ${{ secrets.SSH_USER }}
       ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
+      LETSENCRYPT_BACKUP_AGE_RECIPIENT: ${{ secrets.LETSENCRYPT_BACKUP_AGE_RECIPIENT }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
       HOST_NAME: ${{ secrets.HOST_NAME }}
     steps:
@@ -190,6 +191,7 @@ jobs:
           DOMAINS:
             - $DOMAIN
           ADMIN_EMAIL: $ADMIN_EMAIL
+          LETSENCRYPT_BACKUP_AGE_RECIPIENT: $LETSENCRYPT_BACKUP_AGE_RECIPIENT
           EOF
       - name: Create AWS config and credentials
         env:

--- a/.github/workflows/start_market_data_notification.yml
+++ b/.github/workflows/start_market_data_notification.yml
@@ -191,7 +191,7 @@ jobs:
           DOMAINS:
             - $DOMAIN
           ADMIN_EMAIL: $ADMIN_EMAIL
-          LETSENCRYPT_BACKUP_AGE_RECIPIENT: $LETSENCRYPT_BACKUP_AGE_RECIPIENT
+          LETSENCRYPT_BACKUP_AGE_RECIPIENT: "$LETSENCRYPT_BACKUP_AGE_RECIPIENT"
           EOF
       - name: Create AWS config and credentials
         env:

--- a/.github/workflows/start_market_data_notification.yml
+++ b/.github/workflows/start_market_data_notification.yml
@@ -130,6 +130,7 @@ jobs:
       LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY: ${{ secrets.LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
       HOST_NAME: ${{ secrets.HOST_NAME }}
+      INSTANCE_TAG_NAME: ${{ secrets.INSTANCE_TAG_NAME }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up ansible
@@ -162,26 +163,26 @@ jobs:
 
           # for example, for 2.9: https://github.com/ansible/ansible/blob/stable-2.9/examples/ansible.cfg
           [inventory]
-          enable_plugins = aws_ec2
+          enable_plugins = host_list, script, auto, yaml, ini, toml, amazon.aws.aws_ec2
 
           [defaults]
           host_key_checking = False
+          local_tmp = /tmp/ansible-local
           EOF
 
           # create aws-ec2.yml inventory
           cat << EOF > ./instances/ansible/aws_ec2.yml
-          plugin: aws_ec2
-          regions: us-east-1
-          aws_access_key: $AWS_ACCESS_KEY
-          aws_secret_key: $AWS_SECRET_KEY
+          plugin: amazon.aws.aws_ec2
+          regions:
+            - $AWS_REGION
           keyed_groups:
-            - key: tags
+            - key: ec2_tags
               prefix: tag
-            - key: tags.Name
+            - key: ec2_tags.Name
               separator: ''
           include_filters:
-          - tag:Name:
-            - 'market_data_notification'
+            - tag:Name:
+                - $INSTANCE_TAG_NAME
           EOF
 
           # Create variables

--- a/.github/workflows/start_market_data_notification.yml
+++ b/.github/workflows/start_market_data_notification.yml
@@ -127,7 +127,7 @@ jobs:
       DOMAIN: ${{ secrets.DOMAIN }}
       SSH_USER: ${{ secrets.SSH_USER }}
       ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
-      LETSENCRYPT_BACKUP_AGE_RECIPIENT: ${{ secrets.LETSENCRYPT_BACKUP_AGE_RECIPIENT }}
+      LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY: ${{ secrets.LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
       HOST_NAME: ${{ secrets.HOST_NAME }}
     steps:
@@ -191,7 +191,7 @@ jobs:
           DOMAINS:
             - $DOMAIN
           ADMIN_EMAIL: $ADMIN_EMAIL
-          LETSENCRYPT_BACKUP_AGE_RECIPIENT: "$LETSENCRYPT_BACKUP_AGE_RECIPIENT"
+          LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY: "$LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY"
           EOF
       - name: Create AWS config and credentials
         env:

--- a/.github/workflows/start_market_data_notification.yml
+++ b/.github/workflows/start_market_data_notification.yml
@@ -127,10 +127,10 @@ jobs:
       DOMAIN: ${{ secrets.DOMAIN }}
       SSH_USER: ${{ secrets.SSH_USER }}
       ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
-      LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY: ${{ secrets.LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY }}
+      LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY: ${{ vars.LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
       HOST_NAME: ${{ secrets.HOST_NAME }}
-      INSTANCE_TAG_NAME: ${{ secrets.INSTANCE_TAG_NAME }}
+      INSTANCE_TAG_NAME: ${{ vars.INSTANCE_TAG_NAME }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up ansible

--- a/.github/workflows/start_market_data_notification.yml
+++ b/.github/workflows/start_market_data_notification.yml
@@ -173,12 +173,13 @@ jobs:
           # create aws-ec2.yml inventory
           cat << EOF > ./instances/ansible/aws_ec2.yml
           plugin: amazon.aws.aws_ec2
+          hostvars_prefix: aws_
           regions:
             - $AWS_REGION
           keyed_groups:
-            - key: ec2_tags
+            - key: aws_ec2_tags
               prefix: tag
-            - key: ec2_tags.Name
+            - key: aws_ec2_tags.Name
               separator: ''
           include_filters:
             - tag:Name:
@@ -192,6 +193,7 @@ jobs:
           DOMAINS:
             - $DOMAIN
           ADMIN_EMAIL: $ADMIN_EMAIL
+          ansible_python_interpreter: /usr/bin/python3
           LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY: "$LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY"
           EOF
       - name: Create AWS config and credentials

--- a/.github/workflows/stop_market_data_notification.yml
+++ b/.github/workflows/stop_market_data_notification.yml
@@ -128,6 +128,7 @@ jobs:
     env:
       AWS_REGION: ${{ secrets.AWS_REGION }}
       DOMAIN: ${{ secrets.DOMAIN }}
+      ROUTE53_HOSTED_ZONE_ID: ${{ vars.ROUTE53_HOSTED_ZONE_ID }}
     steps:
       - uses: actions/checkout@v4
       - name: Create AWS config and credentials
@@ -155,7 +156,7 @@ jobs:
       - name: Run stop script
         run: |
           cd instances
-          ./scripts/stop.sh "$DOMAIN"
+          ./scripts/stop.sh
       - name: Cleanup temporary credentials
         if: ${{ always() }}
         run: rm -rf ~/.aws

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ secrets/
 instances/dns.tf
 instances/ansible/aws_ec2.yml
 instances/ansible/vars.yml
+instances/scripts/start.local.env
 instances/scripts/route53/change-record-set.json
 instances/letsencrypt*
 instances/redis*

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ build.log
 
 # --- Secrets & Credentials ---
 secrets/
+*.agekey
 
 # --- Generated/Dynamic Infrastructure Files ---
 instances/dns.tf

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ secrets/
 
 # --- Generated/Dynamic Infrastructure Files ---
 instances/dns.tf
+instances/ansible/ansible.cfg
 instances/ansible/aws_ec2.yml
 instances/ansible/vars.yml
 instances/scripts/start.local.env

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ build.log
 # --- Secrets & Credentials ---
 secrets/
 *.agekey
+*.tar.gz.age
+*.tar.gz
 
 # --- Generated/Dynamic Infrastructure Files ---
 instances/dns.tf

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ This project is the infrastructure as code management for [Market data notificat
 - Ansible is not a standalone day-to-day operator entry point in this repo.
 - The normal operator path runs Ansible through `instances/scripts/start.sh` and `instances/ansible/start.sh`.
 - The current Ansible reconciliation covers:
-  - nginx and certbot TLS setup
-  - the feature-branch Let's Encrypt encrypted backup flow after TLS reconciliation
+  - feature-branch Let's Encrypt backup hook setup before TLS reconciliation
+  - nginx and certbot TLS setup, with encrypted backup upload triggered on successful certificate issuance or renewal
 
 ## 5. Validate live changes carefully
 - For the current Let's Encrypt backup work, use the canonical rollout and restore checklist in [`instances/README.md`](instances/README.md).

--- a/README.md
+++ b/README.md
@@ -4,38 +4,74 @@
 This project is the infrastructure as code management for [Market data notification](https://github.com/hanchiang/market-data-notification) using AWS.
 
 # Structure
-* [`images/`](images): Packer files for building AMI
-    * `image.pkr.hcl`: Main packer script
-    * `scripts/`: Scripts to be run when provisioning AMI
-* [`instances/`](instances): Terraform files to provision EC2 in VPC
-    * `main.tf`: Main terraform script
-    * `ansible/`: Ansible scripts to run post-provisioning tasks such as mounting EBS volume, set up file system, copy postgres data, setup SSL for nginx 
-    * `scripts/`: Scripts that automate the post-provisioning flow: EC2 start and stop, DNS updates, and backend deployment.
+- [`images/`](images): Packer files for building the base AMI
+  - `image.pkr.hcl`: main Packer template
+  - `scripts/`: AMI provisioning scripts
+- [`instances/`](instances): Terraform, Ansible, and orchestration for the EC2 runtime
+  - `main.tf`: main Terraform entry point
+  - `variables.tf`: Terraform variables and AMI lookup
+  - `ansible/`: post-provisioning configuration, including nginx and certbot reconciliation
+  - `scripts/`: start and stop orchestration, Route53 updates, and backend deploy dispatch
 
+# Prerequisites
+- AWS credentials with permission to build the AMI and manage the Terraform-managed resources
+- Terraform Cloud access for the `hansolo/market_data_notification` workspace
+- Packer
+- Terraform
+- Ansible for local script-driven reconciliation flows
+- `jq`, `curl`, and `aws` CLI for the helper scripts
+- SSH access to the target EC2 instance
+- GitHub token access when using `instances/scripts/start.sh`, because that script resolves the latest successful backend build and dispatches deployment
 
-# Workflow
-## 1. Provision EC2 AMI using packer
-Provisions a EBS-backed EC2 AMI, and install the necessary softwares for [Market data notification](https://github.com/hanchiang/market-data-notification):
-* redis
-* docker
-* nginx
+# Operator Workflow
+## 1. Build the base AMI with Packer
+- Work from [`images/`](images).
+- Define the variables used by `image.pkr.hcl` in `variables.auto.pkrvars.hcl`.
+- The current template provisions Ubuntu 22.04 ARM64 and installs:
+  - redis
+  - docker
+  - nginx
+- Build the AMI:
 
-cd into [`images/`](images)  
-Define variables that are declared in `image.pkr.hcl` in a new file `variables.auto.pkrvars.hcl`  
-Build image: `packer build -machine-readable -var-file variables.auto.pkrvars.hcl image.pkr.hcl | tee build.log`
+  ```bash
+  cd images
+  packer build -machine-readable -var-file=variables.auto.pkrvars.hcl image.pkr.hcl | tee build.log
+  ```
 
-## 2. Provision EC2 using terraform
-cd into [`instances/`](instances)  
-Copy the AMI ID from packer build, update it in `variables.tf`  
-Provision infra: `terraform apply`
+- Packer variable details and the current legacy Let's Encrypt artifact input are documented in [`images/README.md`](images/README.md).
 
-Everything from here onwards is handled in `instances/scripts/start.sh`
+## 2. Provision or update infra with Terraform
+- Work from [`instances/`](instances).
+- This repo uses Terraform Cloud, not a local state file.
+- The EC2 AMI is selected by the `data.aws_ami.ec2_ami` lookup in `variables.tf`, which resolves the most recent self-owned AMI named `market_data_notification_t4g_small`.
+- Do not hand-edit `variables.tf` with a copied AMI ID.
+- Use the safe backend/state checklist and rollout guidance in [`instances/README.md`](instances/README.md) before running `terraform plan` or `terraform apply`.
 
-## 3. Run ansible script
-Run post-provisioning configurations such as setting up DNS, configuring nginx SSL
+## 3. Run start or stop orchestration
+- `instances/scripts/start.sh` is the main operator entry point after infrastructure is in place.
+- That script:
+  - starts the EC2 instance if needed
+  - updates Route53
+  - calls `instances/ansible/start.sh`
+  - dispatches the backend deploy workflow using the latest successful backend CI SHA on `master`
+- `instances/scripts/stop.sh` removes the Route53 record and stops the instance.
+- Script-specific behavior is summarized in [`instances/scripts/README.md`](instances/scripts/README.md).
 
-## 4. Deploy application
-Rerun the latest deploy job in github action
+## 4. Understand Ansible's role
+- Ansible is not a standalone day-to-day operator entry point in this repo.
+- The normal operator path runs Ansible through `instances/scripts/start.sh` and `instances/ansible/start.sh`.
+- The current Ansible reconciliation covers:
+  - nginx and certbot TLS setup
+  - the feature-branch Let's Encrypt encrypted backup flow after TLS reconciliation
+
+## 5. Validate live changes carefully
+- For the current Let's Encrypt backup work, use the canonical rollout and restore checklist in [`instances/README.md`](instances/README.md).
+- Keep the older Packer-time Let's Encrypt artifact path as compatibility state until restore has been exercised successfully.
+
+# Canonical Docs
+- Packer usage: [`images/README.md`](images/README.md)
+- Terraform backend, state, apply safety, and Let's Encrypt rollout checklist: [`instances/README.md`](instances/README.md)
+- Start and stop scripts: [`instances/scripts/README.md`](instances/scripts/README.md)
 
 # Diagram
 ![Workflow](readme-images/infra-workflow.png)

--- a/images/README.md
+++ b/images/README.md
@@ -1,2 +1,23 @@
-# Build image
-`packer build -machine-readable -var-file=variables.auto.pkrvars.hcl image.pkr.hcl | tee build.log`
+# Build Image
+
+## Working Directory
+- Run Packer from `images/`.
+
+## Required Inputs
+- Create `variables.auto.pkrvars.hcl` and define the inputs used by `image.pkr.hcl`.
+- The practically relevant inputs today are:
+  - `region`
+  - `ssh_public_key_src_path`
+  - `ssh_public_key_dest_path`
+  - `letsencrypt_src_path`
+  - `letsencrypt_dest_path`
+
+## Notes
+- The build currently copies a local Let's Encrypt artifact into the image build and unpacks it during nginx installation.
+- That path is legacy compatibility state, not the preferred long-term TLS recovery design.
+- Do not deepen reliance on the image-baked Let's Encrypt artifact while the runtime backup and restore path is being introduced.
+
+## Build Command
+```bash
+packer build -machine-readable -var-file=variables.auto.pkrvars.hcl image.pkr.hcl | tee build.log
+```

--- a/images/README.md
+++ b/images/README.md
@@ -4,11 +4,13 @@
 - Run Packer from `images/`.
 
 ## Required Inputs
-- Create `variables.auto.pkrvars.hcl` and define the inputs used by `image.pkr.hcl`.
+- Copy `variables.auto.pkrvars.hcl.example` to `variables.auto.pkrvars.hcl` and fill in the inputs used by `image.pkr.hcl`.
+- `variables.auto.pkrvars.hcl` is local-only and ignored by Git through the repo-wide `*.pkrvars.hcl` rule.
 - The practically relevant inputs today are:
   - `region`
   - `ssh_public_key_src_path`
   - `ssh_public_key_dest_path`
+  - `admin_email`
   - `letsencrypt_src_path`
   - `letsencrypt_dest_path`
 
@@ -19,5 +21,6 @@
 
 ## Build Command
 ```bash
+cp variables.auto.pkrvars.hcl.example variables.auto.pkrvars.hcl
 packer build -machine-readable -var-file=variables.auto.pkrvars.hcl image.pkr.hcl | tee build.log
 ```

--- a/images/variables.auto.pkrvars.hcl.example
+++ b/images/variables.auto.pkrvars.hcl.example
@@ -1,0 +1,9 @@
+region = "your-region"
+
+ssh_public_key_src_path  = "/absolute/path/to/public_key.pub"
+ssh_public_key_dest_path = "/tmp/public_key.pub"
+
+admin_email = "admin@example.com"
+
+letsencrypt_src_path  = "/absolute/path/to/letsencrypt.zip"
+letsencrypt_dest_path = "/tmp/letsencrypt.zip"

--- a/instances/.terraform.lock.hcl
+++ b/instances/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 4.20.1"
   hashes = [
     "h1:1JbjdrwUCLTNVVhlE+acEPnJFJ/FqBTHy5Ooll6nwjI=",
+    "h1:HHfwMYY0FDtMzaGgITqsPIBlUWnQNZ5+bTF1dyscsnw=",
     "zh:21d064d8fac08376c633e002e2f36e83eb7958535e251831feaf38f51c49dafd",
     "zh:3a37912ff43d89ce8d559ec86265d7506801bccb380c7cfb896e8ff24e3fe79d",
     "zh:795eb175c85279ec51dbe12e4d1afa0860c2c0b22e5d36a8e8869f60a93b7931",

--- a/instances/README.md
+++ b/instances/README.md
@@ -1,8 +1,152 @@
-# Provision infra
-`terraform apply`
+# Instance Operations
 
-# Start instance
-`scripts/start.sh <github token> <ssh user> <path to ssh private key>`
+## Scope
+- Run Terraform from `instances/`.
+- Treat `instances/scripts/start.sh` and `instances/scripts/stop.sh` as the normal operator entry points for runtime bring-up and shutdown.
+- Treat `instances/ansible/` as implementation detail unless you are debugging or making infra changes.
 
-# Stop instance
-`scripts/stop.sh`
+## Prerequisites
+- Terraform Cloud access for workspace `hansolo/market_data_notification`
+- AWS credentials with permission to read and modify the Terraform-managed resources
+- `terraform`
+- `aws`
+- `jq`
+- `curl`
+- `ansible-playbook` for local reconciliation or debugging
+- SSH access to the target instance
+
+## Terraform Backend And State
+- `instances/main.tf` uses the Terraform Cloud backend for the `hansolo` organization and the `market_data_notification` workspace.
+- The authoritative Terraform state lives in Terraform Cloud, not in a local `terraform.tfstate` file.
+- Not having a local state file on this machine is normal.
+- Do not run `terraform apply` from a directory initialized with `-backend=false`, because that bypasses the remote backend and can produce a misleading local plan.
+
+### Safe State-Sync Checklist
+1. Authenticate to Terraform Cloud if this machine has not been used for that workspace before:
+
+   ```bash
+   cd instances
+   terraform login
+   ```
+
+2. Initialize the working directory against the configured remote backend:
+
+   ```bash
+   terraform init
+   ```
+
+3. Confirm Terraform can read the remote workspace state before planning:
+
+   ```bash
+   terraform state pull >/tmp/market_data_notification.tfstate
+   ```
+
+4. Review that pulled state file only for confirmation:
+   - it should contain existing managed resources
+   - if it is empty or the command fails, stop before planning or applying
+
+5. Run a read-only plan:
+
+   ```bash
+   terraform plan
+   ```
+
+6. Stop if the plan implies Terraform thinks the existing infrastructure is absent or wants broad destructive changes.
+
+### Drift Inspection And State Sync
+- When you suspect manual AWS drift, inspect it first with:
+
+  ```bash
+  terraform plan -refresh-only
+  ```
+
+- If that output only reflects real remote drift that Terraform state should accept, apply the refresh-only change with:
+
+  ```bash
+  terraform apply -refresh-only
+  ```
+
+- `terraform apply -refresh-only` updates Terraform state to match the real remote objects. It does not modify AWS resources to match the current `.tf` configuration.
+- After any refresh-only apply, immediately run a normal plan again:
+
+  ```bash
+  terraform plan
+  ```
+
+- Do not use refresh-only apply to hide configuration drift you actually intend Terraform to enforce. In particular, immutable EC2 launch attributes can still require replacement in the follow-up normal plan.
+
+### Important Notes
+- `terraform init` does not destroy infrastructure.
+- The real risk is applying from the wrong backend context, not the absence of a local state file.
+- If `terraform state pull` shows the current remote state, Terraform is not treating the cloud as empty.
+- Follow `terraform plan -refresh-only` with a normal `terraform plan` when you suspect manual AWS drift.
+
+## Provision Infra
+- Apply only after reviewing a non-destructive plan:
+
+  ```bash
+  terraform apply
+  ```
+
+## Start Instance
+```bash
+scripts/start.sh <github token> <ssh user> <path to ssh private key>
+```
+
+- `start.sh` is the normal runtime bring-up path.
+- It starts or reuses the EC2 instance, updates Route53, runs Ansible reconciliation, and dispatches backend deployment from the latest successful backend CI SHA on `master`.
+
+## Stop Instance
+```bash
+scripts/stop.sh
+```
+
+- `stop.sh` removes the Route53 record and stops the instance.
+
+## Ansible Reconciliation
+- The normal operator flow reaches Ansible through `scripts/start.sh`, which calls `../ansible/start.sh`.
+- `ansible/start.sh` currently runs:
+  - `playbooks/nginx-https.yml`
+  - `playbooks/letsencrypt-backup.yml` on the feature branch when the backup recipient is configured
+- Treat direct playbook execution as a debugging or change-validation path, not the default operator workflow.
+
+## Let's Encrypt Backup Rollout Checklist
+1. Review `main.tf` and confirm the intended live delta is limited to:
+   - one S3 backup bucket
+   - bucket versioning, server-side encryption, lifecycle retention, and public-access block
+   - one IAM role and instance profile
+   - attachment of the instance profile to the EC2 instance
+2. Confirm the GitHub Actions secret `LETSENCRYPT_BACKUP_AGE_RECIPIENT` is set to the correct operator public key.
+3. Keep the existing AMI-time Let's Encrypt copy path in place for the first rollout.
+4. Run a read-only `terraform plan` against the real remote workspace.
+5. Stop if the plan shows instance replacement, bucket destruction or rename, or unrelated drift.
+6. Apply in a low-risk window where a short startup issue is acceptable.
+7. Trigger one controlled start flow.
+8. Verify TLS still succeeds before treating backup validation as meaningful.
+9. Confirm the host now has:
+   - `/etc/market-data-notification/letsencrypt-backup.env`
+   - `/usr/local/sbin/letsencrypt_backup_to_s3.sh`
+10. From a trusted operator machine, verify a fresh object exists in:
+
+    ```bash
+    aws s3 ls "s3://market-data-notification-le-backup-<account-id>-<region>/letsencrypt/<hostname>/"
+    ```
+
+11. Download one encrypted archive, decrypt it with the operator private key, and inspect the tar members for:
+    - `accounts/`
+    - `live/<domain>/`
+    - `archive/<domain>/`
+    - `renewal/<domain>.conf`
+12. On the host, run one manual backup:
+
+    ```bash
+    sudo /usr/local/sbin/letsencrypt_backup_to_s3.sh
+    ```
+
+13. Confirm the manual run uploads successfully and prints the S3 object path.
+14. Rehearse restore on a non-production target if possible:
+    - restore the decrypted Let's Encrypt state onto the target host
+    - rerun TLS reconciliation
+    - confirm nginx starts with the restored cert material
+15. Treat forced renewal as troubleshooting guidance, not the primary restore-validation step.
+16. Only after a successful restore rehearsal, decide whether to retire the older Packer-time Let's Encrypt copy path.

--- a/instances/README.md
+++ b/instances/README.md
@@ -141,44 +141,63 @@ scripts/stop.sh
 - Treat direct playbook execution as a debugging or change-validation path, not the default operator workflow.
 
 ## Let's Encrypt Backup Rollout Checklist
-1. Review `main.tf` and confirm the intended live delta is limited to:
+1. On a trusted operator machine, generate a dedicated `age` keypair for Let's Encrypt backup decryption:
+
+   ```bash
+   age-keygen -o letsencrypt-backup.agekey
+   ```
+
+   - Keep `letsencrypt-backup.agekey` private, off-host, and outside the Git working tree when possible.
+   - If it is ever created inside the repo by mistake, the repo ignores `*.agekey`, but do not rely on that as the primary safeguard.
+   - Record the printed public key (`age1...`) for the backup configuration.
+
+2. Review `main.tf` and confirm the intended live delta is limited to:
    - one S3 backup bucket
    - bucket versioning, server-side encryption, lifecycle retention, and public-access block
    - one IAM role and instance profile
    - attachment of the instance profile to the EC2 instance
    - one public-subnet update to enable automatic public IPv4 assignment on launch, replacing the previous instance-level public-IP setting
-2. Confirm the GitHub Actions secret `LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY` is set to the correct operator public key.
-3. Keep the existing AMI-time Let's Encrypt copy path in place for the first rollout.
-4. Run a read-only `terraform plan` against the real remote workspace.
-5. Stop if the plan shows instance replacement, bucket destruction or rename, or drift beyond the listed instance-profile and public-subnet changes.
-6. Apply in a low-risk window where a short startup issue is acceptable.
-7. Trigger one controlled start flow.
-8. Verify TLS still succeeds before treating backup validation as meaningful.
-9. Confirm the host now has:
+3. Set `LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY` to that operator public key in the chosen runtime config:
+   - GitHub Actions variable for workflow-driven starts
+   - local `instances/scripts/start.local.env` for local `start.sh` runs
+4. Keep the existing AMI-time Let's Encrypt copy path in place for the first rollout.
+5. Run a read-only `terraform plan` against the real remote workspace.
+6. Stop if the plan shows instance replacement, bucket destruction or rename, or drift beyond the listed instance-profile and public-subnet changes.
+7. Apply in a low-risk window where a short startup issue is acceptable.
+8. Trigger one controlled start flow.
+9. Verify TLS still succeeds before treating backup validation as meaningful.
+10. Confirm the host now has:
    - `/etc/market-data-notification/letsencrypt-backup.env`
    - `/usr/local/sbin/letsencrypt_backup_to_s3.sh`
    - `/etc/letsencrypt/renewal-hooks/deploy/50-market-data-notification-letsencrypt-backup.sh`
-10. If this rollout reused an already-valid certificate and did not issue or renew one during startup, seed the first backup manually on the host:
+11. If this rollout reused an already-valid certificate and did not issue or renew one during startup, seed the first backup manually on the host:
 
     ```bash
     sudo /usr/local/sbin/letsencrypt_backup_to_s3.sh
     ```
 
-11. From a trusted operator machine, verify a fresh object exists in:
+12. From a trusted operator machine, verify a fresh object exists in:
 
     ```bash
     aws s3 ls "s3://market-data-notification-le-backup-<account-id>-<region>/letsencrypt/<hostname>/"
     ```
 
-12. Download one encrypted archive, decrypt it with the operator private key, and inspect the tar members for:
+13. Download one encrypted archive, decrypt it with the operator private key, and inspect the tar members for:
+
+    ```bash
+    aws s3 cp "s3://market-data-notification-le-backup-<account-id>-<region>/letsencrypt/<hostname>/<timestamp>.tar.gz.age" .
+    age -d -i letsencrypt-backup.agekey -o letsencrypt-backup.tar.gz "<timestamp>.tar.gz.age"
+    tar -tzf letsencrypt-backup.tar.gz
+    ```
+
     - `accounts/`
     - `live/<domain>/`
     - `archive/<domain>/`
     - `renewal/<domain>.conf`
-13. Confirm the seed or hook-triggered upload succeeds and prints or results in the expected S3 object path.
-14. Rehearse restore on a non-production target if possible:
+14. Confirm the seed or hook-triggered upload succeeds and prints or results in the expected S3 object path.
+15. Rehearse restore on a non-production target if possible:
     - restore the decrypted Let's Encrypt state onto the target host
     - rerun TLS reconciliation
     - confirm nginx starts with the restored cert material
-15. Treat forced renewal as troubleshooting guidance, not the primary restore-validation step.
-16. Only after a successful restore rehearsal, decide whether to retire the older Packer-time Let's Encrypt copy path.
+16. Treat forced renewal as troubleshooting guidance, not the primary restore-validation step.
+17. Only after a successful restore rehearsal, decide whether to retire the older Packer-time Let's Encrypt copy path.

--- a/instances/README.md
+++ b/instances/README.md
@@ -13,6 +13,7 @@
 - `jq`
 - `curl`
 - `ansible-playbook` for local reconciliation or debugging
+- the `amazon.aws` Ansible collection for the `aws_ec2` dynamic inventory plugin
 - SSH access to the target instance
 
 ## Terraform Backend And State
@@ -85,16 +86,40 @@
 - Apply only after reviewing a non-destructive plan:
 
   ```bash
+  cp terraform.tfvars.example terraform.tfvars
+  ```
+
+- Fill in the local values required by `variables.tf` in `terraform.tfvars`.
+- `terraform.tfvars` is local-only and ignored by Git through the repo-wide `*.tfvars` rule.
+- Keep secret or machine-specific values such as SSH key paths out of tracked files.
+
+  ```bash
+  terraform plan
   terraform apply
   ```
 
 ## Start Instance
 ```bash
+cd instances
 scripts/start.sh <github token> <ssh user> <path to ssh private key>
 ```
 
 - `start.sh` is the normal runtime bring-up path.
+- Running it from `instances/` matches the GitHub Actions workflow path.
 - It starts or reuses the EC2 instance, updates Route53, runs Ansible reconciliation, and dispatches backend deployment from the latest successful backend CI SHA on `master`.
+- For repeat local runs, prefer an ignored local config file at `instances/scripts/start.local.env` using `instances/scripts/start.local.env.example` as the template.
+- Supported config variables are:
+  - `ADMIN_EMAIL` required
+  - `AWS_REGION` required
+  - `DOMAIN` required
+  - `INSTANCE_TAG_NAME` required
+  - `LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY` optional, enables the backup hook when set
+- The local script generates temporary `instances/ansible/ansible.cfg`, `aws_ec2.yml`, and `vars.yml` files before Ansible runs, then removes them on exit.
+- If local Ansible does not have the `amazon.aws` collection, install it with:
+
+  ```bash
+  ansible-galaxy collection install amazon.aws
+  ```
 
 ## Stop Instance
 ```bash

--- a/instances/README.md
+++ b/instances/README.md
@@ -113,6 +113,7 @@ scripts/start.sh <github token> <ssh user> <path to ssh private key>
   - `AWS_REGION` required
   - `DOMAIN` required
   - `INSTANCE_TAG_NAME` required
+  - `ROUTE53_HOSTED_ZONE_ID` required
   - `LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY` optional, enables the backup hook when set
 - The local script generates temporary `instances/ansible/ansible.cfg`, `aws_ec2.yml`, and `vars.yml` files before Ansible runs, then removes them on exit.
 - If local Ansible does not have the `amazon.aws` collection, install it with:

--- a/instances/README.md
+++ b/instances/README.md
@@ -106,8 +106,10 @@ scripts/stop.sh
 ## Ansible Reconciliation
 - The normal operator flow reaches Ansible through `scripts/start.sh`, which calls `../ansible/start.sh`.
 - `ansible/start.sh` currently runs:
+  - `playbooks/letsencrypt-backup.yml` on the feature branch when the backup public key is configured
   - `playbooks/nginx-https.yml`
-  - `playbooks/letsencrypt-backup.yml` on the feature branch when the backup recipient is configured
+- The backup playbook installs the encrypt-and-upload script, env file, and certbot deploy hook.
+- The actual backup upload is triggered by successful certificate issuance or renewal, not by every start run.
 - Treat direct playbook execution as a debugging or change-validation path, not the default operator workflow.
 
 ## Let's Encrypt Backup Rollout Checklist
@@ -127,24 +129,25 @@ scripts/stop.sh
 9. Confirm the host now has:
    - `/etc/market-data-notification/letsencrypt-backup.env`
    - `/usr/local/sbin/letsencrypt_backup_to_s3.sh`
-10. From a trusted operator machine, verify a fresh object exists in:
-
-    ```bash
-    aws s3 ls "s3://market-data-notification-le-backup-<account-id>-<region>/letsencrypt/<hostname>/"
-    ```
-
-11. Download one encrypted archive, decrypt it with the operator private key, and inspect the tar members for:
-    - `accounts/`
-    - `live/<domain>/`
-    - `archive/<domain>/`
-    - `renewal/<domain>.conf`
-12. On the host, run one manual backup:
+   - `/etc/letsencrypt/renewal-hooks/deploy/50-market-data-notification-letsencrypt-backup.sh`
+10. If this rollout reused an already-valid certificate and did not issue or renew one during startup, seed the first backup manually on the host:
 
     ```bash
     sudo /usr/local/sbin/letsencrypt_backup_to_s3.sh
     ```
 
-13. Confirm the manual run uploads successfully and prints the S3 object path.
+11. From a trusted operator machine, verify a fresh object exists in:
+
+    ```bash
+    aws s3 ls "s3://market-data-notification-le-backup-<account-id>-<region>/letsencrypt/<hostname>/"
+    ```
+
+12. Download one encrypted archive, decrypt it with the operator private key, and inspect the tar members for:
+    - `accounts/`
+    - `live/<domain>/`
+    - `archive/<domain>/`
+    - `renewal/<domain>.conf`
+13. Confirm the seed or hook-triggered upload succeeds and prints or results in the expected S3 object path.
 14. Rehearse restore on a non-production target if possible:
     - restore the decrypted Let's Encrypt state onto the target host
     - rerun TLS reconciliation

--- a/instances/README.md
+++ b/instances/README.md
@@ -185,6 +185,16 @@ scripts/stop.sh
 13. Download one encrypted archive, decrypt it with the operator private key, and inspect the tar members for:
 
     ```bash
+    cd instances/scripts
+    ./download_letsencrypt_backup.sh \
+      --hostname <hostname> \
+      --age-key /secure/path/to/letsencrypt-backup.agekey \
+      --region <aws-region>
+    ```
+
+    Or run the equivalent commands manually:
+
+    ```bash
     aws s3 cp "s3://market-data-notification-le-backup-<account-id>-<region>/letsencrypt/<hostname>/<timestamp>.tar.gz.age" .
     age -d -i letsencrypt-backup.agekey -o letsencrypt-backup.tar.gz "<timestamp>.tar.gz.age"
     tar -tzf letsencrypt-backup.tar.gz
@@ -196,8 +206,49 @@ scripts/stop.sh
     - `renewal/<domain>.conf`
 14. Confirm the seed or hook-triggered upload succeeds and prints or results in the expected S3 object path.
 15. Rehearse restore on a non-production target if possible:
-    - restore the decrypted Let's Encrypt state onto the target host
-    - rerun TLS reconciliation
-    - confirm nginx starts with the restored cert material
+    - Use a Linux target or Linux filesystem path for extraction. The archive preserves the `live/<domain>` symlinks into `archive/<domain>`, so extracting through a Windows path such as `\\wsl.localhost\...` can fail even when the archive is valid.
+    - Copy the decrypted archive onto the target host, for example `/tmp/letsencrypt-backup.tar.gz`.
+    - If the target already has Let's Encrypt state, make a reversible backup first:
+
+      ```bash
+      sudo mv /etc/letsencrypt /etc/letsencrypt.before-restore.$(date -u +%Y-%m-%dT%H-%M-%SZ)
+      sudo mkdir -p /etc/letsencrypt
+      ```
+
+    - Extract to a temporary directory and verify the expected tree before touching the live path:
+
+      ```bash
+      sudo mkdir -p /tmp/letsencrypt-restore
+      sudo tar -xzf /tmp/letsencrypt-backup.tar.gz -C /tmp/letsencrypt-restore
+      sudo tar -tzf /tmp/letsencrypt-backup.tar.gz | sed -n '1,40p'
+      sudo ls -l /tmp/letsencrypt-restore/live/<domain>
+      ```
+
+    - Restore the archived state into `/etc/letsencrypt` with metadata and symlinks preserved:
+
+      ```bash
+      sudo cp -a /tmp/letsencrypt-restore/accounts /etc/letsencrypt/
+      sudo cp -a /tmp/letsencrypt-restore/archive /etc/letsencrypt/
+      sudo cp -a /tmp/letsencrypt-restore/live /etc/letsencrypt/
+      sudo cp -a /tmp/letsencrypt-restore/renewal /etc/letsencrypt/
+      ```
+
+    - Confirm the restored `live/<domain>` files are still symlinks into `../../archive/<domain>/...`, and that `fullchain.pem` plus `privkey.pem` exist for each restored domain.
+    - From the operator machine, rerun the host-only reconciliation path so nginx, certbot, and the backup hook are reconciled against the restored state without Route53 or backend deploy side effects:
+
+      ```bash
+      cd instances/scripts
+      ./run_ansible_reconciliation.sh <ssh-user> <path-to-ssh-private-key>
+      ```
+
+    - On the target host, confirm nginx accepts the restored certificate material:
+
+      ```bash
+      sudo nginx -t
+      sudo systemctl status nginx --no-pager
+      sudo ls -l /etc/letsencrypt/live/<domain>
+      ```
+
+    - Treat a forced renewal as troubleshooting guidance only. The first restore validation goal is that nginx and the existing restored certificate state work without needing immediate certificate replacement.
 16. Treat forced renewal as troubleshooting guidance, not the primary restore-validation step.
 17. Only after a successful restore rehearsal, decide whether to retire the older Packer-time Let's Encrypt copy path.

--- a/instances/README.md
+++ b/instances/README.md
@@ -116,10 +116,11 @@ scripts/stop.sh
    - bucket versioning, server-side encryption, lifecycle retention, and public-access block
    - one IAM role and instance profile
    - attachment of the instance profile to the EC2 instance
+   - one public-subnet update to enable automatic public IPv4 assignment on launch, replacing the previous instance-level public-IP setting
 2. Confirm the GitHub Actions secret `LETSENCRYPT_BACKUP_AGE_RECIPIENT` is set to the correct operator public key.
 3. Keep the existing AMI-time Let's Encrypt copy path in place for the first rollout.
 4. Run a read-only `terraform plan` against the real remote workspace.
-5. Stop if the plan shows instance replacement, bucket destruction or rename, or unrelated drift.
+5. Stop if the plan shows instance replacement, bucket destruction or rename, or drift beyond the listed instance-profile and public-subnet changes.
 6. Apply in a low-risk window where a short startup issue is acceptable.
 7. Trigger one controlled start flow.
 8. Verify TLS still succeeds before treating backup validation as meaningful.

--- a/instances/README.md
+++ b/instances/README.md
@@ -117,7 +117,7 @@ scripts/stop.sh
    - one IAM role and instance profile
    - attachment of the instance profile to the EC2 instance
    - one public-subnet update to enable automatic public IPv4 assignment on launch, replacing the previous instance-level public-IP setting
-2. Confirm the GitHub Actions secret `LETSENCRYPT_BACKUP_AGE_RECIPIENT` is set to the correct operator public key.
+2. Confirm the GitHub Actions secret `LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY` is set to the correct operator public key.
 3. Keep the existing AMI-time Let's Encrypt copy path in place for the first rollout.
 4. Run a read-only `terraform plan` against the real remote workspace.
 5. Stop if the plan shows instance replacement, bucket destruction or rename, or drift beyond the listed instance-profile and public-subnet changes.

--- a/instances/README.md
+++ b/instances/README.md
@@ -110,6 +110,8 @@ scripts/stop.sh
   - `playbooks/nginx-https.yml`
 - The backup playbook installs the encrypt-and-upload script, env file, and certbot deploy hook.
 - The actual backup upload is triggered by successful certificate issuance or renewal, not by every start run.
+  - first issuance seeds a backup immediately after successful `certbot --nginx`
+  - later renewals use the certbot deploy hook
 - Treat direct playbook execution as a debugging or change-validation path, not the default operator workflow.
 
 ## Let's Encrypt Backup Rollout Checklist

--- a/instances/ansible/aws_ec2.tpl
+++ b/instances/ansible/aws_ec2.tpl
@@ -1,11 +1,12 @@
 # https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_ec2_inventory.html
 plugin: amazon.aws.aws_ec2
+hostvars_prefix: aws_
 regions:
   - AWS_REGION
 keyed_groups:
-  - key: ec2_tags
+  - key: aws_ec2_tags
     prefix: tag
-  - key: ec2_tags.Name
+  - key: aws_ec2_tags.Name
     separator: ''
 include_filters:
   - tag:Name:

--- a/instances/ansible/aws_ec2.tpl
+++ b/instances/ansible/aws_ec2.tpl
@@ -1,10 +1,12 @@
 # https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_ec2_inventory.html
-plugin: aws_ec2
-regions: us-east-1
-aws_access_key: AWS_ACCESS_KEY
-aws_secret_key: AWS_SECRET_KEY
+plugin: amazon.aws.aws_ec2
+regions:
+  - AWS_REGION
 keyed_groups:
-  - key: tags
+  - key: ec2_tags
     prefix: tag
-  - key: tags.Name
+  - key: ec2_tags.Name
     separator: ''
+include_filters:
+  - tag:Name:
+      - INSTANCE_TAG_NAME

--- a/instances/ansible/files/letsencrypt_backup_to_s3.sh
+++ b/instances/ansible/files/letsencrypt_backup_to_s3.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+# Package the minimal Let's Encrypt recovery state, encrypt it with age,
+# and upload the archive to the configured S3 backup location.
 readonly DEFAULT_ENV_FILE="/etc/market-data-notification/letsencrypt-backup.env"
 ENV_FILE="${LETSENCRYPT_BACKUP_ENV_FILE:-$DEFAULT_ENV_FILE}"
 LETSENCRYPT_ROOT="${LETSENCRYPT_BACKUP_ROOT:-/etc/letsencrypt}"

--- a/instances/ansible/files/letsencrypt_backup_to_s3.sh
+++ b/instances/ansible/files/letsencrypt_backup_to_s3.sh
@@ -36,7 +36,7 @@ require_cmd "$AWS_CLI_BIN"
 require_cmd curl
 require_cmd tar
 
-require_var LETSENCRYPT_BACKUP_AGE_RECIPIENT
+require_var LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY
 require_var LETSENCRYPT_BACKUP_DOMAINS
 
 get_imds_token() {
@@ -154,7 +154,7 @@ main() {
   trap cleanup EXIT
 
   tar -czf "$archive_path" -C "$LETSENCRYPT_ROOT" "${TAR_PATHS[@]}"
-  age -r "$LETSENCRYPT_BACKUP_AGE_RECIPIENT" -o "$encrypted_path" "$archive_path"
+  age -r "$LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY" -o "$encrypted_path" "$archive_path"
 
   "$AWS_CLI_BIN" s3 cp \
     --only-show-errors \

--- a/instances/ansible/files/letsencrypt_backup_to_s3.sh
+++ b/instances/ansible/files/letsencrypt_backup_to_s3.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+set -euo pipefail
+
+readonly DEFAULT_ENV_FILE="/etc/market-data-notification/letsencrypt-backup.env"
+ENV_FILE="${LETSENCRYPT_BACKUP_ENV_FILE:-$DEFAULT_ENV_FILE}"
+LETSENCRYPT_ROOT="${LETSENCRYPT_BACKUP_ROOT:-/etc/letsencrypt}"
+AWS_CLI_BIN="${LETSENCRYPT_BACKUP_AWS_CLI_BIN:-aws}"
+BUCKET_NAME_OVERRIDE="${LETSENCRYPT_BACKUP_BUCKET_NAME:-}"
+REGION_OVERRIDE="${LETSENCRYPT_BACKUP_REGION:-}"
+HOSTNAME_OVERRIDE="${LETSENCRYPT_BACKUP_HOSTNAME:-}"
+S3_PREFIX="${LETSENCRYPT_BACKUP_S3_PREFIX:-letsencrypt}"
+
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+fi
+
+require_var() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "Missing required setting: $name" >&2
+    exit 1
+  fi
+}
+
+require_cmd() {
+  local name="$1"
+  if ! command -v "$name" >/dev/null 2>&1; then
+    echo "Missing required command: $name" >&2
+    exit 1
+  fi
+}
+
+require_cmd age
+require_cmd "$AWS_CLI_BIN"
+require_cmd curl
+require_cmd tar
+
+require_var LETSENCRYPT_BACKUP_AGE_RECIPIENT
+require_var LETSENCRYPT_BACKUP_DOMAINS
+
+get_imds_token() {
+  curl -fsS -X PUT \
+    -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" \
+    "http://169.254.169.254/latest/api/token"
+}
+
+get_region() {
+  if [[ -n "$REGION_OVERRIDE" ]]; then
+    printf '%s\n' "$REGION_OVERRIDE"
+    return 0
+  fi
+
+  local token="$1"
+  curl -fsS \
+    -H "X-aws-ec2-metadata-token: $token" \
+    "http://169.254.169.254/latest/dynamic/instance-identity/document" | \
+    python3 -c 'import json,sys; print(json.load(sys.stdin)["region"])'
+}
+
+get_bucket_name() {
+  if [[ -n "$BUCKET_NAME_OVERRIDE" ]]; then
+    printf '%s\n' "$BUCKET_NAME_OVERRIDE"
+    return 0
+  fi
+
+  local region="$1"
+  local account_id
+  account_id="$("$AWS_CLI_BIN" sts get-caller-identity --query Account --output text)"
+  printf 'market-data-notification-le-backup-%s-%s\n' "$account_id" "$region"
+}
+
+get_hostname_short() {
+  if [[ -n "$HOSTNAME_OVERRIDE" ]]; then
+    printf '%s\n' "$HOSTNAME_OVERRIDE"
+    return 0
+  fi
+
+  hostname -s
+}
+
+verify_backup_paths() {
+  local domain
+  for domain in $LETSENCRYPT_BACKUP_DOMAINS; do
+    [[ -d "$LETSENCRYPT_ROOT/live/$domain" ]] || {
+      echo "Missing live certificate directory for $domain" >&2
+      exit 1
+    }
+    [[ -d "$LETSENCRYPT_ROOT/archive/$domain" ]] || {
+      echo "Missing archive directory for $domain" >&2
+      exit 1
+    }
+    [[ -f "$LETSENCRYPT_ROOT/renewal/$domain.conf" ]] || {
+      echo "Missing renewal config for $domain" >&2
+      exit 1
+    }
+    [[ -s "$LETSENCRYPT_ROOT/live/$domain/fullchain.pem" ]] || {
+      echo "Missing fullchain.pem for $domain" >&2
+      exit 1
+    }
+    [[ -s "$LETSENCRYPT_ROOT/live/$domain/privkey.pem" ]] || {
+      echo "Missing privkey.pem for $domain" >&2
+      exit 1
+    }
+  done
+
+  [[ -d "$LETSENCRYPT_ROOT/accounts" ]] || {
+    echo "Missing letsencrypt accounts directory" >&2
+    exit 1
+  }
+}
+
+build_tar_args() {
+  TAR_PATHS=("accounts")
+
+  local domain
+  for domain in $LETSENCRYPT_BACKUP_DOMAINS; do
+    TAR_PATHS+=(
+      "live/$domain"
+      "archive/$domain"
+      "renewal/$domain.conf"
+    )
+  done
+}
+
+main() {
+  verify_backup_paths
+  build_tar_args
+
+  local region
+  local token=""
+  if [[ -z "$REGION_OVERRIDE" ]]; then
+    token="$(get_imds_token)"
+  fi
+  region="$(get_region "$token")"
+
+  local bucket_name
+  bucket_name="$(get_bucket_name "$region")"
+  local hostname_short
+  hostname_short="$(get_hostname_short)"
+  local timestamp
+  timestamp="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+
+  local workdir
+  workdir="$(mktemp -d /tmp/letsencrypt-backup.XXXXXX)"
+  local cleanup_workdir="$workdir"
+  local archive_path="$workdir/letsencrypt-backup-${timestamp}.tar.gz"
+  local encrypted_path="${archive_path}.age"
+  local s3_key="${S3_PREFIX}/${hostname_short}/${timestamp}.tar.gz.age"
+
+  cleanup() {
+    rm -rf "${cleanup_workdir:-}"
+  }
+  trap cleanup EXIT
+
+  tar -czf "$archive_path" -C "$LETSENCRYPT_ROOT" "${TAR_PATHS[@]}"
+  age -r "$LETSENCRYPT_BACKUP_AGE_RECIPIENT" -o "$encrypted_path" "$archive_path"
+
+  "$AWS_CLI_BIN" s3 cp \
+    --only-show-errors \
+    --sse AES256 \
+    "$encrypted_path" \
+    "s3://${bucket_name}/${s3_key}"
+
+  echo "Uploaded encrypted Let's Encrypt backup to s3://${bucket_name}/${s3_key}"
+}
+
+main "$@"

--- a/instances/ansible/playbooks/letsencrypt-backup.yml
+++ b/instances/ansible/playbooks/letsencrypt-backup.yml
@@ -5,11 +5,11 @@
   vars_files:
     - ../vars.yml
   vars:
-    letsencrypt_backup_enabled: "{{ (LETSENCRYPT_BACKUP_AGE_RECIPIENT | default('', true) | string | trim | length) > 0 }}"
+    letsencrypt_backup_enabled: "{{ (LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY | default('', true) | string | trim | length) > 0 }}"
   tasks:
-    - name: Skip Let's Encrypt backup installation when no recipient is configured
+    - name: Skip Let's Encrypt backup installation when no public key is configured
       debug:
-        msg: "Skipping Let's Encrypt backup install because LETSENCRYPT_BACKUP_AGE_RECIPIENT is not configured."
+        msg: "Skipping Let's Encrypt backup install because LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY is not configured."
       when: not letsencrypt_backup_enabled
 
     - name: Install packages for Let's Encrypt backup
@@ -40,7 +40,7 @@
         group: root
         mode: "0600"
         content: |
-          LETSENCRYPT_BACKUP_AGE_RECIPIENT={{ LETSENCRYPT_BACKUP_AGE_RECIPIENT }}
+          LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY={{ LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY }}
           LETSENCRYPT_BACKUP_DOMAINS="{{ DOMAINS | join(' ') }}"
       when: letsencrypt_backup_enabled
 

--- a/instances/ansible/playbooks/letsencrypt-backup.yml
+++ b/instances/ansible/playbooks/letsencrypt-backup.yml
@@ -1,0 +1,76 @@
+- hosts: market_data_notification
+  name: Install Let's Encrypt backup flow
+  remote_user: "{{ USER }}"
+  gather_facts: no
+  vars_files:
+    - ../vars.yml
+  vars:
+    letsencrypt_backup_enabled: "{{ LETSENCRYPT_BACKUP_AGE_RECIPIENT | default('') | length > 0 }}"
+  tasks:
+    - name: Skip Let's Encrypt backup installation when no recipient is configured
+      debug:
+        msg: "Skipping Let's Encrypt backup install because LETSENCRYPT_BACKUP_AGE_RECIPIENT is not configured."
+      when: not letsencrypt_backup_enabled
+
+    - name: Install packages for Let's Encrypt backup
+      become: yes
+      apt:
+        name:
+          - age
+          - awscli
+        state: present
+        update_cache: yes
+      when: letsencrypt_backup_enabled
+
+    - name: Ensure backup config directory exists
+      become: yes
+      file:
+        path: /etc/market-data-notification
+        state: directory
+        owner: root
+        group: root
+        mode: "0750"
+      when: letsencrypt_backup_enabled
+
+    - name: Install Let's Encrypt backup env file
+      become: yes
+      copy:
+        dest: /etc/market-data-notification/letsencrypt-backup.env
+        owner: root
+        group: root
+        mode: "0600"
+        content: |
+          LETSENCRYPT_BACKUP_AGE_RECIPIENT={{ LETSENCRYPT_BACKUP_AGE_RECIPIENT }}
+          LETSENCRYPT_BACKUP_DOMAINS="{{ DOMAINS | join(' ') }}"
+      when: letsencrypt_backup_enabled
+
+    - name: Install Let's Encrypt backup script
+      become: yes
+      copy:
+        src: ../files/letsencrypt_backup_to_s3.sh
+        dest: /usr/local/sbin/letsencrypt_backup_to_s3.sh
+        owner: root
+        group: root
+        mode: "0700"
+      when: letsencrypt_backup_enabled
+
+    - name: Upload encrypted Let's Encrypt backup to S3
+      args:
+        executable: /bin/bash
+      become: yes
+      register: letsencrypt_backup
+      failed_when: false
+      shell: |
+        /usr/local/sbin/letsencrypt_backup_to_s3.sh
+      when: letsencrypt_backup_enabled
+
+    - debug: var=letsencrypt_backup.stdout_lines
+      when: letsencrypt_backup_enabled
+    - debug: var=letsencrypt_backup.stderr_lines
+      when: letsencrypt_backup_enabled
+    - name: Warn when Let's Encrypt backup upload fails
+      debug:
+        msg: "Let's Encrypt backup upload failed with rc={{ letsencrypt_backup.rc }}"
+      when:
+        - letsencrypt_backup_enabled
+        - letsencrypt_backup.rc != 0

--- a/instances/ansible/playbooks/letsencrypt-backup.yml
+++ b/instances/ansible/playbooks/letsencrypt-backup.yml
@@ -24,6 +24,16 @@
         msg: "Skipping Let's Encrypt backup install because LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY is not configured."
       when: not letsencrypt_backup_enabled
 
+    - name: Remove obsolete nginx stable PPA source before apt refresh
+      become: yes
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /etc/apt/sources.list.d/nginx-ubuntu-stable-jammy.list
+        - /etc/apt/sources.list.d/nginx-ubuntu-stable-jammy.list.save
+      when: letsencrypt_backup_enabled
+
     - name: Install packages for Let's Encrypt backup
       become: yes
       apt:

--- a/instances/ansible/playbooks/letsencrypt-backup.yml
+++ b/instances/ansible/playbooks/letsencrypt-backup.yml
@@ -6,7 +6,19 @@
     - ../vars.yml
   vars:
     letsencrypt_backup_enabled: "{{ (LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY | default('', true) | string | trim | length) > 0 }}"
+    letsencrypt_backup_deploy_hook_path: /etc/letsencrypt/renewal-hooks/deploy/50-market-data-notification-letsencrypt-backup.sh
   tasks:
+    - name: Remove Let's Encrypt backup hook artifacts when no public key is configured
+      become: yes
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ letsencrypt_backup_deploy_hook_path }}"
+        - /etc/market-data-notification/letsencrypt-backup.env
+        - /usr/local/sbin/letsencrypt_backup_to_s3.sh
+      when: not letsencrypt_backup_enabled
+
     - name: Skip Let's Encrypt backup installation when no public key is configured
       debug:
         msg: "Skipping Let's Encrypt backup install because LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY is not configured."
@@ -54,23 +66,25 @@
         mode: "0700"
       when: letsencrypt_backup_enabled
 
-    - name: Upload encrypted Let's Encrypt backup to S3
-      args:
-        executable: /bin/bash
+    - name: Ensure certbot deploy-hook directory exists
       become: yes
-      register: letsencrypt_backup
-      failed_when: false
-      shell: |
-        /usr/local/sbin/letsencrypt_backup_to_s3.sh
+      file:
+        path: /etc/letsencrypt/renewal-hooks/deploy
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
       when: letsencrypt_backup_enabled
 
-    - debug: var=letsencrypt_backup.stdout_lines
+    - name: Install Let's Encrypt backup deploy hook
+      become: yes
+      copy:
+        dest: "{{ letsencrypt_backup_deploy_hook_path }}"
+        owner: root
+        group: root
+        mode: "0755"
+        content: |
+          #!/bin/bash
+          set -euo pipefail
+          /usr/local/sbin/letsencrypt_backup_to_s3.sh
       when: letsencrypt_backup_enabled
-    - debug: var=letsencrypt_backup.stderr_lines
-      when: letsencrypt_backup_enabled
-    - name: Warn when Let's Encrypt backup upload fails
-      debug:
-        msg: "Let's Encrypt backup upload failed with rc={{ letsencrypt_backup.rc }}"
-      when:
-        - letsencrypt_backup_enabled
-        - letsencrypt_backup.rc != 0

--- a/instances/ansible/playbooks/letsencrypt-backup.yml
+++ b/instances/ansible/playbooks/letsencrypt-backup.yml
@@ -5,7 +5,7 @@
   vars_files:
     - ../vars.yml
   vars:
-    letsencrypt_backup_enabled: "{{ LETSENCRYPT_BACKUP_AGE_RECIPIENT | default('') | length > 0 }}"
+    letsencrypt_backup_enabled: "{{ (LETSENCRYPT_BACKUP_AGE_RECIPIENT | default('', true) | string | trim | length) > 0 }}"
   tasks:
     - name: Skip Let's Encrypt backup installation when no recipient is configured
       debug:

--- a/instances/ansible/playbooks/nginx-https.yml
+++ b/instances/ansible/playbooks/nginx-https.yml
@@ -6,8 +6,8 @@
     - ../vars.yml
   vars:
     letsencrypt_backup_enabled: "{{ (LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY | default('', true) | string | trim | length) > 0 }}"
-    certbot_renew_command: >-
-      /usr/bin/certbot --quiet renew{% if letsencrypt_backup_enabled %} --deploy-hook /usr/local/sbin/letsencrypt_backup_to_s3.sh{% endif %}
+    certbot_renew_cli: /usr/bin/certbot --quiet renew
+    certbot_renew_cron_line: "0 12-23 * * * {{ certbot_renew_cli }}"
   tasks:
     - name: Install required packages for SSL
       args:
@@ -50,17 +50,21 @@
           echo "Saving a backup of /etc/nginx/sites-available/{{ DOMAIN }}"
           cp /etc/nginx/sites-available/{{ DOMAIN }} /etc/nginx/sites-available/{{ DOMAIN }}.bak
 
-          certbot --nginx -d {{ item }} --non-interactive --agree-tos -m {{ ADMIN_EMAIL }}{% if letsencrypt_backup_enabled %} --deploy-hook /usr/local/sbin/letsencrypt_backup_to_s3.sh{% endif %}
+          certbot --nginx -d {{ item }} --non-interactive --agree-tos -m {{ ADMIN_EMAIL }}
 
           sleep 10
+
+          {% if letsencrypt_backup_enabled %}
+          /usr/local/sbin/letsencrypt_backup_to_s3.sh
+          {% endif %}
         fi
 
         sudo systemctl force-reload nginx
-        sudo certbot renew --dry-run
+        {{ certbot_renew_cli }} --dry-run
 
         # cron
         (crontab -l 2>/dev/null || true) | grep -v -F '/usr/bin/certbot --quiet renew' > mycron || true
-        echo '{{ certbot_renew_command }}' >> mycron
+        echo '{{ certbot_renew_cron_line }}' >> mycron
 
         sort -u mycron > mycron.temp
         mv mycron.temp mycron
@@ -194,4 +198,3 @@
         sudo systemctl reload nginx
     - debug: var=update_nginx_config.stdout_lines
     - debug: var=update_nginx_config.stderr_lines
-

--- a/instances/ansible/playbooks/nginx-https.yml
+++ b/instances/ansible/playbooks/nginx-https.yml
@@ -4,6 +4,10 @@
   gather_facts: no
   vars_files:
     - ../vars.yml
+  vars:
+    letsencrypt_backup_enabled: "{{ (LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY | default('', true) | string | trim | length) > 0 }}"
+    certbot_renew_command: >-
+      /usr/bin/certbot --quiet renew{% if letsencrypt_backup_enabled %} --deploy-hook /usr/local/sbin/letsencrypt_backup_to_s3.sh{% endif %}
   tasks:
     - name: Install required packages for SSL
       args:
@@ -46,7 +50,7 @@
           echo "Saving a backup of /etc/nginx/sites-available/{{ DOMAIN }}"
           cp /etc/nginx/sites-available/{{ DOMAIN }} /etc/nginx/sites-available/{{ DOMAIN }}.bak
 
-          certbot --nginx -d {{ item }} --non-interactive --agree-tos -m {{ ADMIN_EMAIL }}
+          certbot --nginx -d {{ item }} --non-interactive --agree-tos -m {{ ADMIN_EMAIL }}{% if letsencrypt_backup_enabled %} --deploy-hook /usr/local/sbin/letsencrypt_backup_to_s3.sh{% endif %}
 
           sleep 10
         fi
@@ -55,13 +59,13 @@
         sudo certbot renew --dry-run
 
         # cron
-        crontab -l > mycron
-        echo "0 12-23 * * * /usr/bin/certbot --quiet renew" >> mycron
+        (crontab -l 2>/dev/null || true) | grep -v -F '/usr/bin/certbot --quiet renew' > mycron || true
+        echo '{{ certbot_renew_command }}' >> mycron
 
-        mv mycron mycron.temp
-        cat mycron.temp | sort | uniq > mycron
-        cp mycron mycron.bak
+        sort -u mycron > mycron.temp
+        mv mycron.temp mycron
         crontab mycron
+        rm -f mycron
     - debug:
         var: item.stdout_lines
       loop: "{{ install_ssl.results }}"
@@ -190,5 +194,4 @@
         sudo systemctl reload nginx
     - debug: var=update_nginx_config.stdout_lines
     - debug: var=update_nginx_config.stderr_lines
-
 

--- a/instances/ansible/start.sh
+++ b/instances/ansible/start.sh
@@ -23,14 +23,14 @@ then
     usage
 fi
 
-# Configure ssl for nginx
-ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u "$SSH_USER" -i aws_ec2.yml --private-key "$SSH_PRIVATE_KEY_PATH" playbooks/nginx-https.yml
-
-# Install and run the encrypted Let's Encrypt backup flow after TLS reconciliation.
-# Backup reconciliation is intentionally non-blocking so a backup-path problem
-# does not prevent the runtime from starting.
+# Install the encrypted Let's Encrypt backup prerequisites before TLS reconciliation.
+# Backup setup is intentionally non-blocking so a backup-path problem does not
+# prevent the runtime from starting. Successful cert issuance or renewal then
+# triggers the actual upload via certbot deploy hooks.
 if ! ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u "$SSH_USER" -i aws_ec2.yml --private-key "$SSH_PRIVATE_KEY_PATH" playbooks/letsencrypt-backup.yml
 then
-    echo "Warning: Let's Encrypt backup reconciliation failed; continuing startup" >&2
+    echo "Warning: Let's Encrypt backup hook setup failed; continuing startup" >&2
 fi
 
+# Configure ssl for nginx
+ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u "$SSH_USER" -i aws_ec2.yml --private-key "$SSH_PRIVATE_KEY_PATH" playbooks/nginx-https.yml

--- a/instances/ansible/start.sh
+++ b/instances/ansible/start.sh
@@ -1,9 +1,9 @@
 #! /bin/bash
 
-set -u
+set -euo pipefail
 
-dir=$(dirname $0)
-cd $dir
+dir=$(dirname "$0")
+cd "$dir"
 
 SSH_USER=$1
 SSH_PRIVATE_KEY_PATH=$2
@@ -23,11 +23,14 @@ then
     usage
 fi
 
-files=($(ls playbooks/*.yml))
-
 # Configure ssl for nginx
-ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u $SSH_USER -i aws_ec2.yml --private-key $SSH_PRIVATE_KEY_PATH playbooks/nginx-https.yml
+ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u "$SSH_USER" -i aws_ec2.yml --private-key "$SSH_PRIVATE_KEY_PATH" playbooks/nginx-https.yml
 
-
-
+# Install and run the encrypted Let's Encrypt backup flow after TLS reconciliation.
+# Backup reconciliation is intentionally non-blocking so a backup-path problem
+# does not prevent the runtime from starting.
+if ! ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u "$SSH_USER" -i aws_ec2.yml --private-key "$SSH_PRIVATE_KEY_PATH" playbooks/letsencrypt-backup.yml
+then
+    echo "Warning: Let's Encrypt backup reconciliation failed; continuing startup" >&2
+fi
 

--- a/instances/ansible/start.sh
+++ b/instances/ansible/start.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+# Run the host Ansible playbooks in order: install backup prerequisites first,
+# then reconcile nginx and certbot TLS state.
 dir=$(dirname "$0")
 cd "$dir"
 

--- a/instances/main.tf
+++ b/instances/main.tf
@@ -148,11 +148,11 @@ resource "aws_s3_bucket_lifecycle_configuration" "letsencrypt_backup" {
     status = "Enabled"
 
     expiration {
-      days = 60
+      days = 180
     }
 
     noncurrent_version_expiration {
-      noncurrent_days = 30
+      noncurrent_days = 14
     }
   }
 }

--- a/instances/main.tf
+++ b/instances/main.tf
@@ -20,6 +20,14 @@ provider "aws" {
   region = var.region
 }
 
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+locals {
+  letsencrypt_backup_bucket_name = "market-data-notification-le-backup-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
+}
+
 resource "aws_vpc" "vpc" {
   cidr_block           = var.cidr_vpc
   enable_dns_support   = true
@@ -37,9 +45,10 @@ resource "aws_internet_gateway" "igw" {
 }
 
 resource "aws_subnet" "subnet_public" {
-  vpc_id     = aws_vpc.vpc.id
-  cidr_block = var.cidr_subnet
-  availability_zone = var.ec2_az
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = var.cidr_subnet
+  availability_zone       = var.ec2_az
+  map_public_ip_on_launch = true
   tags = {
     Name = "market_data_notification"
   }
@@ -96,21 +105,122 @@ resource "aws_security_group" "sg_22_80_443" {
   }
 }
 
+resource "aws_s3_bucket" "letsencrypt_backup" {
+  bucket = local.letsencrypt_backup_bucket_name
+
+  tags = {
+    Name = "market_data_notification_letsencrypt_backup"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "letsencrypt_backup" {
+  bucket = aws_s3_bucket.letsencrypt_backup.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "letsencrypt_backup" {
+  bucket = aws_s3_bucket.letsencrypt_backup.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "letsencrypt_backup" {
+  bucket = aws_s3_bucket.letsencrypt_backup.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "letsencrypt_backup" {
+  bucket = aws_s3_bucket.letsencrypt_backup.id
+
+  rule {
+    id     = "expire-letsencrypt-backups"
+    status = "Enabled"
+
+    expiration {
+      days = 60
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+
+resource "aws_iam_role" "letsencrypt_backup" {
+  name = "market_data_notification_letsencrypt_backup"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "letsencrypt_backup" {
+  name = "market_data_notification_letsencrypt_backup"
+  role = aws_iam_role.letsencrypt_backup.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetBucketLocation",
+          "s3:ListBucket"
+        ]
+        Resource = aws_s3_bucket.letsencrypt_backup.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject"
+        ]
+        Resource = "${aws_s3_bucket.letsencrypt_backup.arn}/*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_instance_profile" "letsencrypt_backup" {
+  name = "market_data_notification_letsencrypt_backup"
+  role = aws_iam_role.letsencrypt_backup.name
+}
+
 resource "aws_instance" "web" {
-  ami                         = data.aws_ami.ec2_ami.id
-  instance_type               = var.ec2_instance_type
-  subnet_id                   = aws_subnet.subnet_public.id
-  vpc_security_group_ids      = [aws_security_group.sg_22_80_443.id]
-  availability_zone = var.ec2_az
-  associate_public_ip_address = true
+  ami                    = data.aws_ami.ec2_ami.id
+  instance_type          = var.ec2_instance_type
+  subnet_id              = aws_subnet.subnet_public.id
+  vpc_security_group_ids = [aws_security_group.sg_22_80_443.id]
+  availability_zone      = var.ec2_az
+  iam_instance_profile   = aws_iam_instance_profile.letsencrypt_backup.name
   credit_specification {
     cpu_credits = "standard"
   }
 
   root_block_device {
     delete_on_termination = true
-    volume_size = 20
-    volume_type = "gp2"
+    volume_size           = 20
+    volume_type           = "gp2"
 
     tags = {
       Name = "market_data_notification"
@@ -122,9 +232,9 @@ resource "aws_instance" "web" {
     inline = ["echo 'EC2 is ready'"]
 
     connection {
-      type = "ssh"
-      user = var.ssh_user
-      host = self.public_ip
+      type        = "ssh"
+      user        = var.ssh_user
+      host        = self.public_ip
       private_key = file(var.ssh_private_key_path)
     }
   }
@@ -150,4 +260,6 @@ output "ebs_root_device_name" {
   value = aws_instance.web.root_block_device.0.device_name
 }
 
-
+output "letsencrypt_backup_bucket_name" {
+  value = aws_s3_bucket.letsencrypt_backup.bucket
+}

--- a/instances/main.tf
+++ b/instances/main.tf
@@ -45,9 +45,11 @@ resource "aws_internet_gateway" "igw" {
 }
 
 resource "aws_subnet" "subnet_public" {
-  vpc_id                  = aws_vpc.vpc.id
-  cidr_block              = var.cidr_subnet
-  availability_zone       = var.ec2_az
+  vpc_id            = aws_vpc.vpc.id
+  cidr_block        = var.cidr_subnet
+  availability_zone = var.ec2_az
+  # Keep public IPv4 assignment at the subnet so existing instances avoid
+  # replacement from immutable instance-level associate_public_ip_address drift.
   map_public_ip_on_launch = true
   tags = {
     Name = "market_data_notification"

--- a/instances/scripts/README.md
+++ b/instances/scripts/README.md
@@ -2,7 +2,7 @@
 
 The `scripts/` directory automates EC2 runtime bring-up, shutdown, Route53 updates, and backend deployment handoff for [Market data notification](https://github.com/hanchiang/market-data-notification).
 
-Run these scripts from `instances/scripts/`.
+Run `start.sh` from `instances/` so the local invocation matches the GitHub Actions workflow.
 
 ## `start.sh`
 - Starts the EC2 instance if needed
@@ -17,8 +17,21 @@ Run these scripts from `instances/scripts/`.
 Inputs:
 
 ```bash
-./start.sh <github token> <ssh user> <path to ssh private key>
+cd instances
+scripts/start.sh <github token> <ssh user> <path to ssh private key>
 ```
+
+- For repeat local runs, prefer an ignored config file at `start.local.env` next to `start.sh`.
+- Template: `start.local.env.example`
+- Supported variables:
+  - `ADMIN_EMAIL` required
+  - `AWS_REGION` required
+  - `DOMAIN` required
+  - `INSTANCE_TAG_NAME` required
+  - `LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY` optional
+- Local prerequisites:
+  - AWS credentials must already be available through the normal AWS SDK/CLI credential chain
+  - local Ansible must have the `amazon.aws` collection installed for the `aws_ec2` inventory plugin
 
 ## `stop.sh`
 - Removes the Route53 record

--- a/instances/scripts/README.md
+++ b/instances/scripts/README.md
@@ -47,6 +47,7 @@ cd instances/scripts
 ## `stop.sh`
 - Removes the Route53 record
 - Stops the EC2 instance
+- Uses the same `start.local.env` convenience file as `start.sh` for `DOMAIN` and `ROUTE53_HOSTED_ZONE_ID`
 
 ```bash
 ./stop.sh

--- a/instances/scripts/README.md
+++ b/instances/scripts/README.md
@@ -1,14 +1,29 @@
-# Introduction
-The scripts folder contains scripts to automate starting and stopping of AWS EC2, DNS, and deployment of [Market data notification](https://github.com/hanchiang/market-data-notification)
-Scripts should be run at this directory.
+# Script Overview
 
-`start.sh`
-* Start EC2
-* Update route53 record, wait for DNS record to be updated
-* Ansible:
-  * Configure SSL for nginx
-* Re-run github action deployment job for URL shortener
+The `scripts/` directory automates EC2 runtime bring-up, shutdown, Route53 updates, and backend deployment handoff for [Market data notification](https://github.com/hanchiang/market-data-notification).
 
-`stop.sh`
-* Remove route53 record
-* Stop EC2
+Run these scripts from `instances/scripts/`.
+
+## `start.sh`
+- Starts the EC2 instance if needed
+- Waits for the instance to be running
+- Updates the Route53 record for the service domain
+- Calls `../ansible/start.sh` to reconcile host configuration
+  - nginx and certbot TLS setup
+  - feature-branch Let's Encrypt backup reconciliation after TLS setup
+- Resolves the latest successful backend CI build on `master`
+- Dispatches the backend deploy workflow using that image SHA
+
+Inputs:
+
+```bash
+./start.sh <github token> <ssh user> <path to ssh private key>
+```
+
+## `stop.sh`
+- Removes the Route53 record
+- Stops the EC2 instance
+
+```bash
+./stop.sh
+```

--- a/instances/scripts/README.md
+++ b/instances/scripts/README.md
@@ -9,8 +9,8 @@ Run these scripts from `instances/scripts/`.
 - Waits for the instance to be running
 - Updates the Route53 record for the service domain
 - Calls `../ansible/start.sh` to reconcile host configuration
-  - nginx and certbot TLS setup
-  - feature-branch Let's Encrypt backup reconciliation after TLS setup
+  - feature-branch Let's Encrypt backup hook setup before TLS reconciliation
+  - nginx and certbot TLS setup, with encrypted backup upload triggered on successful certificate issuance or renewal
 - Resolves the latest successful backend CI build on `master`
 - Dispatches the backend deploy workflow using that image SHA
 

--- a/instances/scripts/README.md
+++ b/instances/scripts/README.md
@@ -34,6 +34,16 @@ scripts/start.sh <github token> <ssh user> <path to ssh private key>
   - AWS credentials must already be available through the normal AWS SDK/CLI credential chain
   - local Ansible must have the `amazon.aws` collection installed for the `aws_ec2` inventory plugin
 
+## `run_ansible_reconciliation.sh`
+- Runs the host Ansible reconciliation only
+- Avoids the Route53 update and backend deploy side effects from `start.sh`
+- Use this for restore rehearsal or host-only recovery validation
+
+```bash
+cd instances/scripts
+./run_ansible_reconciliation.sh <ssh user> <path to ssh private key>
+```
+
 ## `stop.sh`
 - Removes the Route53 record
 - Stops the EC2 instance
@@ -41,3 +51,22 @@ scripts/start.sh <github token> <ssh user> <path to ssh private key>
 ```bash
 ./stop.sh
 ```
+
+## `download_letsencrypt_backup.sh`
+- Downloads the latest encrypted Let's Encrypt backup for a host from S3 by default
+- Decrypts it with the operator `age` private key
+- Lists the tar members so the backup can be verified quickly
+
+```bash
+cd instances/scripts
+./download_letsencrypt_backup.sh \
+  --hostname <hostname> \
+  --age-key /secure/path/to/letsencrypt-backup.agekey \
+  --region <aws-region>
+```
+
+- If `--bucket` is omitted, the script derives `market-data-notification-le-backup-<account-id>-<region>`.
+- If `--s3-key` is omitted, the script downloads the most recently uploaded object under `letsencrypt/<hostname>/`.
+- By default, it writes the encrypted and decrypted files to the current directory.
+- Use `--output-dir` to write them somewhere else.
+- The repo ignores `*.tar.gz.age` and `*.tar.gz` so downloaded backup artifacts are not staged accidentally.

--- a/instances/scripts/README.md
+++ b/instances/scripts/README.md
@@ -28,6 +28,7 @@ scripts/start.sh <github token> <ssh user> <path to ssh private key>
   - `AWS_REGION` required
   - `DOMAIN` required
   - `INSTANCE_TAG_NAME` required
+  - `ROUTE53_HOSTED_ZONE_ID` required
   - `LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY` optional
 - Local prerequisites:
   - AWS credentials must already be available through the normal AWS SDK/CLI credential chain

--- a/instances/scripts/download_letsencrypt_backup.sh
+++ b/instances/scripts/download_letsencrypt_backup.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+usage: download_letsencrypt_backup.sh --hostname <hostname> --age-key <path> [options]
+
+Downloads and decrypts a Let's Encrypt backup archive from S3.
+
+Required:
+  --hostname <hostname>     Hostname segment used in the S3 key prefix.
+  --age-key <path>          Path to the operator age private key.
+
+Optional:
+  --bucket <name>           Override the backup bucket name.
+  --region <region>         AWS region used to derive the default bucket name.
+  --s3-key <key>            Download a specific S3 object key instead of the latest one.
+  --output-dir <path>       Directory for the downloaded and decrypted files. Default: current directory.
+  --s3-prefix <prefix>      Backup object prefix. Default: letsencrypt.
+  --skip-list               Skip listing decrypted tar members after download.
+  -h, --help                Show this help text.
+EOF
+}
+
+require_cmd() {
+    local name="$1"
+    if ! command -v "$name" >/dev/null 2>&1
+    then
+        echo "Missing required command: $name" >&2
+        exit 1
+    fi
+}
+
+require_file() {
+    local path="$1"
+    if [[ ! -f "$path" ]]
+    then
+        echo "Missing required file: $path" >&2
+        exit 1
+    fi
+}
+
+get_default_region() {
+    if [[ -n "${AWS_REGION:-}" ]]
+    then
+        printf '%s\n' "$AWS_REGION"
+        return 0
+    fi
+
+    if [[ -n "${AWS_DEFAULT_REGION:-}" ]]
+    then
+        printf '%s\n' "$AWS_DEFAULT_REGION"
+        return 0
+    fi
+
+    aws configure get region 2>/dev/null || true
+}
+
+resolve_bucket_name() {
+    local region="$1"
+    local account_id
+    account_id="$(aws sts get-caller-identity --query Account --output text)"
+    printf 'market-data-notification-le-backup-%s-%s\n' "$account_id" "$region"
+}
+
+resolve_latest_s3_key() {
+    local bucket_name="$1"
+    local s3_prefix="$2"
+    local hostname="$3"
+
+    local key
+    key="$(aws s3api list-objects-v2 \
+        --bucket "$bucket_name" \
+        --prefix "${s3_prefix}/${hostname}/" \
+        --query 'reverse(sort_by(Contents, &LastModified))[0].Key' \
+        --output text)"
+
+    if [[ -z "$key" || "$key" == "None" ]]
+    then
+        echo "No Let's Encrypt backup objects found under s3://${bucket_name}/${s3_prefix}/${hostname}/" >&2
+        exit 1
+    fi
+
+    printf '%s\n' "$key"
+}
+
+HOSTNAME_SHORT=""
+AGE_KEY_PATH=""
+BUCKET_NAME=""
+AWS_REGION_ARG=""
+S3_KEY=""
+OUTPUT_DIR="$PWD"
+S3_PREFIX="${LETSENCRYPT_BACKUP_S3_PREFIX:-letsencrypt}"
+LIST_TAR_CONTENTS=true
+
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        --hostname)
+            HOSTNAME_SHORT="${2:-}"
+            shift 2
+            ;;
+        --age-key)
+            AGE_KEY_PATH="${2:-}"
+            shift 2
+            ;;
+        --bucket)
+            BUCKET_NAME="${2:-}"
+            shift 2
+            ;;
+        --region)
+            AWS_REGION_ARG="${2:-}"
+            shift 2
+            ;;
+        --s3-key)
+            S3_KEY="${2:-}"
+            shift 2
+            ;;
+        --output-dir)
+            OUTPUT_DIR="${2:-}"
+            shift 2
+            ;;
+        --s3-prefix)
+            S3_PREFIX="${2:-}"
+            shift 2
+            ;;
+        --skip-list)
+            LIST_TAR_CONTENTS=false
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$HOSTNAME_SHORT" || -z "$AGE_KEY_PATH" ]]
+then
+    usage >&2
+    exit 1
+fi
+
+require_cmd aws
+require_cmd age
+require_cmd tar
+require_file "$AGE_KEY_PATH"
+
+if [[ -z "$BUCKET_NAME" ]]
+then
+    if [[ -z "$AWS_REGION_ARG" ]]
+    then
+        AWS_REGION_ARG="$(get_default_region)"
+    fi
+
+    if [[ -z "$AWS_REGION_ARG" ]]
+    then
+        echo "AWS region is required when --bucket is not provided" >&2
+        exit 1
+    fi
+
+    BUCKET_NAME="$(resolve_bucket_name "$AWS_REGION_ARG")"
+fi
+
+if [[ -z "$S3_KEY" ]]
+then
+    S3_KEY="$(resolve_latest_s3_key "$BUCKET_NAME" "$S3_PREFIX" "$HOSTNAME_SHORT")"
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+ENCRYPTED_BASENAME="$(basename "$S3_KEY")"
+ENCRYPTED_PATH="${OUTPUT_DIR}/${ENCRYPTED_BASENAME}"
+DECRYPTED_PATH="${OUTPUT_DIR}/${ENCRYPTED_BASENAME%.age}"
+
+aws s3 cp \
+    --only-show-errors \
+    "s3://${BUCKET_NAME}/${S3_KEY}" \
+    "$ENCRYPTED_PATH"
+
+age -d -i "$AGE_KEY_PATH" -o "$DECRYPTED_PATH" "$ENCRYPTED_PATH"
+
+echo "Downloaded encrypted backup: $ENCRYPTED_PATH"
+echo "Decrypted archive: $DECRYPTED_PATH"
+
+if [[ "$LIST_TAR_CONTENTS" == true ]]
+then
+    echo "Archive contents:"
+    tar -tzf "$DECRYPTED_PATH"
+fi

--- a/instances/scripts/helper/timer.sh
+++ b/instances/scripts/helper/timer.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+# Lightweight timing helper for polling loops in the operator scripts.
 get_time_elapsed () {
     start_time_in_seconds=$1
 

--- a/instances/scripts/helper/wait_for_route53_change.sh
+++ b/instances/scripts/helper/wait_for_route53_change.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 
+# Poll a Route53 change request until it reaches INSYNC or times out.
 source ./helper/timer.sh
 
 wait_for_route53_change () {

--- a/instances/scripts/route53/update-ec2-route53.sh
+++ b/instances/scripts/route53/update-ec2-route53.sh
@@ -128,8 +128,8 @@ fi
 #### Update route53 record set
 for ip in "${ip_addresses[@]}"
 do
-    record_set_file="route53/change-record-set.json"
-    record_set_template_file="route53/change-record-set.json.tpl"
+    record_set_file="$SCRIPT_DIR/change-record-set.json"
+    record_set_template_file="$SCRIPT_DIR/change-record-set.json.tpl"
 
     sed "s~<INSTANCE_IP_ADDRESS>~$ip~" "$record_set_template_file" \
     | sed "s~<DOMAIN>~$DOMAIN~" | sed "s~<ACTION>~$ACTION~" | sed "s~<TTL>~$TTL~" > "$record_set_file"

--- a/instances/scripts/route53/update-ec2-route53.sh
+++ b/instances/scripts/route53/update-ec2-route53.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+# Idempotent Route53 helper for the service A record used by the start/stop scripts.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 

--- a/instances/scripts/route53/update-ec2-route53.sh
+++ b/instances/scripts/route53/update-ec2-route53.sh
@@ -2,9 +2,13 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
 DOMAIN=${1:-}
 ACTION=${2:-}
 TTL=${3:-}
+ROUTE53_HOSTED_ZONE_ID=${ROUTE53_HOSTED_ZONE_ID:-}
 
 if [ -z "$DOMAIN" ]
 then
@@ -20,31 +24,95 @@ if [ -z "$TTL" ]
 then
     TTL=300
 fi
+if [ -z "$ROUTE53_HOSTED_ZONE_ID" ]
+then
+    echo "ROUTE53_HOSTED_ZONE_ID is required" >&2
+    exit 1
+fi
 
-source ./helper/ec2-helper.sh
+source "$SCRIPT_DIR/../helper/ec2-helper.sh"
+
+normalize_domain() {
+    local domain="$1"
+    if [[ "$domain" == *. ]]
+    then
+        printf '%s\n' "$domain"
+    else
+        printf '%s.\n' "$domain"
+    fi
+}
+
+get_existing_a_record() {
+    local normalized_domain="$1"
+
+    aws route53 list-resource-record-sets \
+        --hosted-zone-id "$ROUTE53_HOSTED_ZONE_ID" \
+        --start-record-name "$normalized_domain" \
+        --start-record-type A \
+        --max-items 1 | \
+        jq --arg name "$normalized_domain" \
+           '.ResourceRecordSets[0] | select(.Name == $name and .Type == "A")'
+}
+
+record_matches_desired_state() {
+    local record_json="$1"
+    local desired_ttl="$2"
+
+    if [ -z "$record_json" ] || [ "$record_json" = "null" ]
+    then
+        return 1
+    fi
+
+    local existing_ttl
+    existing_ttl=$(echo "$record_json" | jq -r '.TTL')
+    if [ "$existing_ttl" != "$desired_ttl" ]
+    then
+        return 1
+    fi
+
+    local existing_values desired_values
+    existing_values=$(echo "$record_json" | jq -r '.ResourceRecords[].Value' | sort)
+    desired_values=$(printf '%s\n' "${ip_addresses[@]}" | sort)
+
+    if [ "$existing_values" != "$desired_values" ]
+    then
+        return 1
+    fi
+
+    return 0
+}
 
 instance_id=""
+normalized_domain=$(normalize_domain "$DOMAIN")
 
 if [ "$ACTION" == "UPSERT" ] || [ "$ACTION" == "CREATE" ]
 then
     instance_info=$(get_instance_info)
-    instance_ip_address=$(echo $instance_info | jq -r '.ip_address')
-    instance_state=$(echo $instance_info | jq -r '.state')
-    instance_id=$(echo $instance_info | jq -r .'id')
-    ip_addresses=($instance_ip_address)
+    instance_ip_address=$(echo "$instance_info" | jq -r '.ip_address')
+    instance_id=$(echo "$instance_info" | jq -r '.id')
+    ip_addresses=("$instance_ip_address")
 elif [ "$ACTION" == "DELETE" ]
 then
-    command=$(echo "aws route53 list-resource-record-sets --hosted-zone-id Z036374065L40GHHCTH5 | jq '.ResourceRecordSets[] | select (.Name | contains(\"$DOMAIN\")) | select(.Type == \"A\")'")
-    record=$(eval $command)
+    record=$(get_existing_a_record "$normalized_domain")
     if [ -z "$record" ]
     then
         echo "No existing route53 A record found for domain $DOMAIN; nothing to delete" >&2
         exit 0
     fi
-    ip_addresses=($(echo $record | jq -r '.ResourceRecords[].Value'))
+    mapfile -t ip_addresses < <(echo "$record" | jq -r '.ResourceRecords[].Value')
 else
     echo "Unrecognised action $ACTION"
     exit 1
+fi
+
+if [ "$ACTION" == "UPSERT" ]
+then
+    existing_record=$(get_existing_a_record "$normalized_domain")
+    if record_matches_desired_state "$existing_record" "$TTL"
+    then
+        echo "Route53 A record for $DOMAIN already points at ${ip_addresses[*]} with TTL $TTL; skipping update" >&2
+        exit 0
+    fi
 fi
 
 change_ids=()
@@ -62,11 +130,11 @@ do
     record_set_file="route53/change-record-set.json"
     record_set_template_file="route53/change-record-set.json.tpl"
 
-    cat $record_set_template_file | sed "s~<INSTANCE_IP_ADDRESS>~$ip~" \
-    | sed "s~<DOMAIN>~$DOMAIN~" | sed "s~<ACTION>~$ACTION~" | sed "s~<TTL>~$TTL~" > $record_set_file
-    change_id=$(aws route53 change-resource-record-sets --hosted-zone-id Z036374065L40GHHCTH5 --change-batch file://$record_set_file | jq -r '.ChangeInfo.Id')
+    sed "s~<INSTANCE_IP_ADDRESS>~$ip~" "$record_set_template_file" \
+    | sed "s~<DOMAIN>~$DOMAIN~" | sed "s~<ACTION>~$ACTION~" | sed "s~<TTL>~$TTL~" > "$record_set_file"
+    change_id=$(aws route53 change-resource-record-sets --hosted-zone-id "$ROUTE53_HOSTED_ZONE_ID" --change-batch file://"$record_set_file" | jq -r '.ChangeInfo.Id')
 
-    rm $record_set_file
+    rm "$record_set_file"
     echo "Updated route53 record for ip address $ip, action $ACTION, TTL $TTL, change $change_id" >&2
     change_ids+=("$change_id")
 done

--- a/instances/scripts/run_ansible_reconciliation.sh
+++ b/instances/scripts/run_ansible_reconciliation.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]
+then
+    echo "Run this script directly, do not source it." >&2
+    return 1 2>/dev/null || exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+SSH_USER=${1:-}
+SSH_PRIVATE_KEY_PATH=${2:-}
+ANSIBLE_DIR="$(cd ../ansible && pwd)"
+ANSIBLE_LOCAL_TEMP_DIR=${ANSIBLE_LOCAL_TEMP:-/tmp/ansible-local}
+ANSIBLE_CONFIG_PATH="$ANSIBLE_DIR/ansible.cfg"
+ANSIBLE_INVENTORY_PATH="$ANSIBLE_DIR/aws_ec2.yml"
+ANSIBLE_VARS_PATH="$ANSIBLE_DIR/vars.yml"
+START_ENV_FILE=${START_ENV_FILE:-"$SCRIPT_DIR/start.local.env"}
+
+if [ -f "$START_ENV_FILE" ]
+then
+    # shellcheck disable=SC1090
+    source "$START_ENV_FILE"
+fi
+
+AWS_REGION=${AWS_REGION:-}
+DOMAIN=${DOMAIN:-}
+ADMIN_EMAIL=${ADMIN_EMAIL:-}
+LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY=${LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY:-}
+INSTANCE_TAG_NAME=${INSTANCE_TAG_NAME:-}
+
+usage() {
+    echo "usage: <path/to/script> <ssh user> <ssh private key path>" >&2
+    exit 1
+}
+
+require_cmd() {
+    local name="$1"
+    if ! command -v "$name" >/dev/null 2>&1
+    then
+        echo "Missing required command: $name" >&2
+        exit 1
+    fi
+}
+
+require_env() {
+    local name="$1"
+    local value="$2"
+    if [ -z "$value" ]
+    then
+        echo "Missing required environment variable: $name" >&2
+        exit 1
+    fi
+}
+
+if [ -z "$SSH_USER" ] || [ -z "$SSH_PRIVATE_KEY_PATH" ]
+then
+    usage
+fi
+
+require_cmd ansible-playbook
+require_cmd ansible-doc
+require_env ADMIN_EMAIL "$ADMIN_EMAIL"
+require_env AWS_REGION "$AWS_REGION"
+require_env DOMAIN "$DOMAIN"
+require_env INSTANCE_TAG_NAME "$INSTANCE_TAG_NAME"
+
+mkdir -p "$ANSIBLE_LOCAL_TEMP_DIR"
+
+cat << EOF > "$ANSIBLE_CONFIG_PATH"
+[inventory]
+enable_plugins = host_list, script, auto, yaml, ini, toml, amazon.aws.aws_ec2
+
+[defaults]
+host_key_checking = False
+local_tmp = $ANSIBLE_LOCAL_TEMP_DIR
+EOF
+
+if ! ANSIBLE_CONFIG="$ANSIBLE_CONFIG_PATH" ANSIBLE_LOCAL_TEMP="$ANSIBLE_LOCAL_TEMP_DIR" ansible-doc -t inventory -l 2>/dev/null | grep -Eq '^amazon\.aws\.aws_ec2([[:space:]]|$)'
+then
+    echo "Missing Ansible inventory plugin amazon.aws.aws_ec2. Install it with: ansible-galaxy collection install amazon.aws" >&2
+    exit 1
+fi
+
+cat << EOF > "$ANSIBLE_INVENTORY_PATH"
+plugin: amazon.aws.aws_ec2
+hostvars_prefix: aws_
+regions:
+  - $AWS_REGION
+keyed_groups:
+  - key: aws_ec2_tags
+    prefix: tag
+  - key: aws_ec2_tags.Name
+    separator: ''
+include_filters:
+  - tag:Name:
+      - $INSTANCE_TAG_NAME
+EOF
+
+cat << EOF > "$ANSIBLE_VARS_PATH"
+USER: $SSH_USER
+DOMAIN: $DOMAIN
+DOMAINS:
+  - $DOMAIN
+ADMIN_EMAIL: $ADMIN_EMAIL
+ansible_python_interpreter: /usr/bin/python3
+LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY: "$LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY"
+EOF
+
+cleanup_ansible_inputs() {
+    rm -f "$ANSIBLE_CONFIG_PATH" "$ANSIBLE_INVENTORY_PATH" "$ANSIBLE_VARS_PATH"
+}
+
+trap cleanup_ansible_inputs EXIT
+
+ANSIBLE_CONFIG="$ANSIBLE_CONFIG_PATH" \
+ANSIBLE_LOCAL_TEMP="$ANSIBLE_LOCAL_TEMP_DIR" \
+../ansible/start.sh "$SSH_USER" "$SSH_PRIVATE_KEY_PATH"

--- a/instances/scripts/run_ansible_reconciliation.sh
+++ b/instances/scripts/run_ansible_reconciliation.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+# Host-only reconciliation wrapper for the Ansible playbooks used by start.sh.
+# This avoids Route53 updates and backend deploy side effects during restore checks.
 if [[ "${BASH_SOURCE[0]}" != "$0" ]]
 then
     echo "Run this script directly, do not source it." >&2

--- a/instances/scripts/start.local.env.example
+++ b/instances/scripts/start.local.env.example
@@ -12,5 +12,8 @@ DOMAIN=your.domain.example
 # Required. Set the EC2 Name tag used by the inventory filter.
 INSTANCE_TAG_NAME=your-instance-tag
 
+# Required. Set the Route53 hosted zone ID for DNS updates.
+ROUTE53_HOSTED_ZONE_ID=your-hosted-zone-id
+
 # Optional. When set, start.sh installs the Let's Encrypt backup hook.
 LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY=

--- a/instances/scripts/start.local.env.example
+++ b/instances/scripts/start.local.env.example
@@ -1,0 +1,16 @@
+# Copy this file to start.local.env for repeat local start.sh runs.
+
+# Required for certbot issuance and renewal registration.
+ADMIN_EMAIL=admin@example.com
+
+# Required. Set the AWS region for the EC2 inventory lookup.
+AWS_REGION=your-region
+
+# Required. Set the TLS domain to reconcile.
+DOMAIN=your.domain.example
+
+# Required. Set the EC2 Name tag used by the inventory filter.
+INSTANCE_TAG_NAME=your-instance-tag
+
+# Optional. When set, start.sh installs the Let's Encrypt backup hook.
+LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY=

--- a/instances/scripts/start.sh
+++ b/instances/scripts/start.sh
@@ -257,7 +257,7 @@ wait_for_ec2_stop
 start_ec2
 
 # Update route53 record
-DOMAINS=("api.marketdata.yaphc.com")
+DOMAINS=("$DOMAIN")
 for domain in "${DOMAINS[@]}"
 do
     change_ids=$(./route53/update-ec2-route53.sh "$domain" "UPSERT")

--- a/instances/scripts/start.sh
+++ b/instances/scripts/start.sh
@@ -1,6 +1,12 @@
 #! /bin/bash
 set -euo pipefail
 
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]
+then
+    echo "Run this script directly, do not source it." >&2
+    return 1 2>/dev/null || exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
@@ -99,12 +105,13 @@ fi
 
 cat << EOF > "$ANSIBLE_INVENTORY_PATH"
 plugin: amazon.aws.aws_ec2
+hostvars_prefix: aws_
 regions:
   - $AWS_REGION
 keyed_groups:
-  - key: ec2_tags
+  - key: aws_ec2_tags
     prefix: tag
-  - key: ec2_tags.Name
+  - key: aws_ec2_tags.Name
     separator: ''
 include_filters:
   - tag:Name:
@@ -117,6 +124,7 @@ DOMAIN: $DOMAIN
 DOMAINS:
   - $DOMAIN
 ADMIN_EMAIL: $ADMIN_EMAIL
+ansible_python_interpreter: /usr/bin/python3
 LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY: "$LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY"
 EOF
 
@@ -275,13 +283,21 @@ then
     echo "No deploy image SHA resolved from CI"
     exit 1
 fi
-deploy_workflow=$(curl -fsSL -H "Accept: application/vnd.github+json" -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/hanchiang/market-data-notification/actions/workflows" | jq '.workflows[] | select(.state == "active" and select(.name | ascii_downcase | contains("build and deploy")))')
+deploy_workflow_json=$(curl -fsSL \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    "https://api.github.com/repos/hanchiang/market-data-notification/actions/workflows")
+deploy_workflow=$(jq '.workflows[] | select(.state == "active" and (.name | ascii_downcase | contains("build and deploy")))' <<< "$deploy_workflow_json")
 printf "\n"
 
 workflow_id=$(echo "$deploy_workflow" | jq -r '.id')
 deploy_payload=$(jq -n --arg image_sha "$deploy_image_sha" '{ref:"master",inputs:{image_sha:$image_sha,allow_unverified_image:"true"}}')
-curl -fsSL -X POST  -H "Accept: application/vnd.github+json" -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/hanchiang/market-data-notification/actions/workflows/$workflow_id/dispatches" \
- -d "$deploy_payload"
+curl -fsSL \
+    -X POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    "https://api.github.com/repos/hanchiang/market-data-notification/actions/workflows/$workflow_id/dispatches" \
+    -d "$deploy_payload"
 printf "\n"
 
 echo "Script completed in $SECONDS seconds"

--- a/instances/scripts/start.sh
+++ b/instances/scripts/start.sh
@@ -1,20 +1,57 @@
 #! /bin/bash
 set -euo pipefail
 
-dir=$(dirname "$0")
-cd "$dir"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
 
-source ./helper/ec2-helper.sh
-source ./helper/wait_for_route53_change.sh
-source ./helper/timer.sh
+source "$SCRIPT_DIR/helper/ec2-helper.sh"
+source "$SCRIPT_DIR/helper/wait_for_route53_change.sh"
+source "$SCRIPT_DIR/helper/timer.sh"
 
 GITHUB_TOKEN=${1:-}
 SSH_USER=${2:-}
 SSH_PRIVATE_KEY_PATH=${3:-}
+ANSIBLE_DIR="$(cd ../ansible && pwd)"
+ANSIBLE_LOCAL_TEMP_DIR=${ANSIBLE_LOCAL_TEMP:-/tmp/ansible-local}
+ANSIBLE_CONFIG_PATH="$ANSIBLE_DIR/ansible.cfg"
+ANSIBLE_INVENTORY_PATH="$ANSIBLE_DIR/aws_ec2.yml"
+ANSIBLE_VARS_PATH="$ANSIBLE_DIR/vars.yml"
+START_ENV_FILE=${START_ENV_FILE:-"$SCRIPT_DIR/start.local.env"}
+
+if [ -f "$START_ENV_FILE" ];
+then
+    # shellcheck disable=SC1090
+    source "$START_ENV_FILE"
+fi
+
+AWS_REGION=${AWS_REGION:-}
+DOMAIN=${DOMAIN:-}
+ADMIN_EMAIL=${ADMIN_EMAIL:-}
+LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY=${LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY:-}
+INSTANCE_TAG_NAME=${INSTANCE_TAG_NAME:-}
 
 usage () {
     echo "Invalid $1. usage: <path/to/script> <github token> <ssh user> <ssh private key path>"
     exit 1
+}
+
+require_cmd() {
+    local name="$1"
+    if ! command -v "$name" >/dev/null 2>&1
+    then
+        echo "Missing required command: $name" >&2
+        exit 1
+    fi
+}
+
+require_env() {
+    local name="$1"
+    local value="$2"
+    if [ -z "$value" ]
+    then
+        echo "Missing required environment variable: $name" >&2
+        exit 1
+    fi
 }
 
 if [ -z "$GITHUB_TOKEN"  ];
@@ -31,6 +68,59 @@ if [ -z "$SSH_PRIVATE_KEY_PATH"  ];
 then
     usage "ssh private key path"
 fi
+
+require_cmd ansible-playbook
+require_cmd ansible-doc
+require_env ADMIN_EMAIL "$ADMIN_EMAIL"
+require_env AWS_REGION "$AWS_REGION"
+require_env DOMAIN "$DOMAIN"
+require_env INSTANCE_TAG_NAME "$INSTANCE_TAG_NAME"
+
+mkdir -p "$ANSIBLE_LOCAL_TEMP_DIR"
+
+cat << EOF > "$ANSIBLE_CONFIG_PATH"
+[inventory]
+enable_plugins = host_list, script, auto, yaml, ini, toml, amazon.aws.aws_ec2
+
+[defaults]
+host_key_checking = False
+local_tmp = $ANSIBLE_LOCAL_TEMP_DIR
+EOF
+
+if ! ANSIBLE_CONFIG="$ANSIBLE_CONFIG_PATH" ANSIBLE_LOCAL_TEMP="$ANSIBLE_LOCAL_TEMP_DIR" ansible-doc -t inventory -l 2>/dev/null | grep -Eq '^amazon\.aws\.aws_ec2([[:space:]]|$)'
+then
+    echo "Missing Ansible inventory plugin amazon.aws.aws_ec2. Install it with: ansible-galaxy collection install amazon.aws" >&2
+    exit 1
+fi
+
+cat << EOF > "$ANSIBLE_INVENTORY_PATH"
+plugin: amazon.aws.aws_ec2
+regions:
+  - $AWS_REGION
+keyed_groups:
+  - key: ec2_tags
+    prefix: tag
+  - key: ec2_tags.Name
+    separator: ''
+include_filters:
+  - tag:Name:
+      - $INSTANCE_TAG_NAME
+EOF
+
+cat << EOF > "$ANSIBLE_VARS_PATH"
+USER: $SSH_USER
+DOMAIN: $DOMAIN
+DOMAINS:
+  - $DOMAIN
+ADMIN_EMAIL: $ADMIN_EMAIL
+LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY: "$LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY"
+EOF
+
+cleanup_ansible_inputs() {
+    rm -f "$ANSIBLE_CONFIG_PATH" "$ANSIBLE_INVENTORY_PATH" "$ANSIBLE_VARS_PATH"
+}
+
+trap cleanup_ansible_inputs EXIT
 
 
 #### Start EC2
@@ -170,6 +260,8 @@ done
 sleep 10
 
 # Configure EC2
+ANSIBLE_CONFIG="$ANSIBLE_CONFIG_PATH" \
+ANSIBLE_LOCAL_TEMP="$ANSIBLE_LOCAL_TEMP_DIR" \
 ../ansible/start.sh "$SSH_USER" "$SSH_PRIVATE_KEY_PATH"
 
 # Re-run deploy workflow

--- a/instances/scripts/start.sh
+++ b/instances/scripts/start.sh
@@ -1,6 +1,8 @@
 #! /bin/bash
 set -euo pipefail
 
+# Full operator start path: ensure the instance is running, reconcile DNS and host config,
+# then dispatch the backend deploy workflow once infra is ready.
 if [[ "${BASH_SOURCE[0]}" != "$0" ]]
 then
     echo "Run this script directly, do not source it." >&2

--- a/instances/scripts/start.sh
+++ b/instances/scripts/start.sh
@@ -29,6 +29,7 @@ DOMAIN=${DOMAIN:-}
 ADMIN_EMAIL=${ADMIN_EMAIL:-}
 LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY=${LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY:-}
 INSTANCE_TAG_NAME=${INSTANCE_TAG_NAME:-}
+ROUTE53_HOSTED_ZONE_ID=${ROUTE53_HOSTED_ZONE_ID:-}
 
 usage () {
     echo "Invalid $1. usage: <path/to/script> <github token> <ssh user> <ssh private key path>"
@@ -75,6 +76,9 @@ require_env ADMIN_EMAIL "$ADMIN_EMAIL"
 require_env AWS_REGION "$AWS_REGION"
 require_env DOMAIN "$DOMAIN"
 require_env INSTANCE_TAG_NAME "$INSTANCE_TAG_NAME"
+require_env ROUTE53_HOSTED_ZONE_ID "$ROUTE53_HOSTED_ZONE_ID"
+
+export ROUTE53_HOSTED_ZONE_ID
 
 mkdir -p "$ANSIBLE_LOCAL_TEMP_DIR"
 
@@ -275,8 +279,9 @@ deploy_workflow=$(curl -fsSL -H "Accept: application/vnd.github+json" -H "Author
 printf "\n"
 
 workflow_id=$(echo "$deploy_workflow" | jq -r '.id')
+deploy_payload=$(jq -n --arg image_sha "$deploy_image_sha" '{ref:"master",inputs:{image_sha:$image_sha,allow_unverified_image:"true"}}')
 curl -fsSL -X POST  -H "Accept: application/vnd.github+json" -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/hanchiang/market-data-notification/actions/workflows/$workflow_id/dispatches" \
- -d "{\"ref\":\"master\",\"inputs\":{\"image_sha\":\"$deploy_image_sha\",\"allow_unverified_image\":\"true\"}}"
+ -d "$deploy_payload"
 printf "\n"
 
 echo "Script completed in $SECONDS seconds"

--- a/instances/scripts/start.sh
+++ b/instances/scripts/start.sh
@@ -1,8 +1,8 @@
 #! /bin/bash
 set -euo pipefail
 
-dir=$(dirname $0)
-cd $dir
+dir=$(dirname "$0")
+cd "$dir"
 
 source ./helper/ec2-helper.sh
 source ./helper/wait_for_route53_change.sh
@@ -37,10 +37,10 @@ fi
 
 wait_for_ec2_stop () {
     instance_info=$(get_instance_info)
-    echo $instance_info
-    instance_ip_address=$(echo $instance_info | jq -r '.ip_address')
-    instance_state=$(echo $instance_info | jq -r '.state')
-    instance_id=$(echo $instance_info | jq -r .'id')
+    echo "$instance_info"
+    instance_ip_address=$(echo "$instance_info" | jq -r '.ip_address')
+    instance_state=$(echo "$instance_info" | jq -r '.state')
+    instance_id=$(echo "$instance_info" | jq -r '.id')
     
     if [ "$instance_state" = "running" ]
     then
@@ -58,14 +58,14 @@ wait_for_ec2_stop () {
         local seconds_to_wait=180
 
         start=$(date +%s)
-        time_elapsed=$(get_time_elapsed $start | tail -n 1)
+        time_elapsed=$(get_time_elapsed "$start" | tail -n 1)
 
         while [ "$instance_state" != "stopped" ] && [ "$time_elapsed" -lt "$seconds_to_wait" ];
         do
             echo "Waiting for instance $instance_id to be stopped"
             sleep 10
             instance_info=$(get_instance_info)
-            instance_state=$(echo $instance_info | jq -r '.state')
+            instance_state=$(echo "$instance_info" | jq -r '.state')
 
             if [ "$instance_state" == "stopped" ]
             then
@@ -73,7 +73,7 @@ wait_for_ec2_stop () {
                 printf "\n"
                 return 0
             fi
-            time_elapsed=$(get_time_elapsed $start | tail -n 1)
+            time_elapsed=$(get_time_elapsed "$start" | tail -n 1)
         done
         echo "Instance $instance_id did not stop after $seconds_to_wait seconds"
         return 1
@@ -84,9 +84,9 @@ wait_for_ec2_stop () {
 
 start_ec2() {
     instance_info=$(get_instance_info)
-    instance_state=$(echo $instance_info | jq -r '.state')
-    instance_id=$(echo $instance_info | jq -r .'id')
-    instance_ip_address=$(echo $instance_info | jq -r '.ip_address')
+    instance_state=$(echo "$instance_info" | jq -r '.state')
+    instance_id=$(echo "$instance_info" | jq -r '.id')
+    instance_ip_address=$(echo "$instance_info" | jq -r '.ip_address')
 
     if [ "$instance_state" == "running" ]
     then
@@ -98,10 +98,10 @@ start_ec2() {
     local seconds_to_wait=180
 
     start=$(date +%s)
-    time_elapsed=$(get_time_elapsed $start | tail -n 1)
+    time_elapsed=$(get_time_elapsed "$start" | tail -n 1)
 
     echo "Starting ec2 $instance_id"
-    aws ec2 start-instances --instance-ids $instance_id > /dev/null
+    aws ec2 start-instances --instance-ids "$instance_id" > /dev/null
 
     while [ "$instance_state" != "running" ] && [ "$time_elapsed" -lt "$seconds_to_wait" ];
     do
@@ -109,9 +109,9 @@ start_ec2() {
         sleep 10
 
         instance_info=$(get_instance_info)
-        instance_state=$(echo $instance_info | jq -r '.state')
-        instance_id=$(echo $instance_info | jq -r .'id')
-        instance_ip_address=$(echo $instance_info | jq -r '.ip_address')
+        instance_state=$(echo "$instance_info" | jq -r '.state')
+        instance_id=$(echo "$instance_info" | jq -r '.id')
+        instance_ip_address=$(echo "$instance_info" | jq -r '.ip_address')
 
         if [ "$instance_state" == "running" ]
         then
@@ -119,7 +119,7 @@ start_ec2() {
             printf "\n"
             return 0
         fi
-        time_elapsed=$(get_time_elapsed $start | tail -n 1)
+        time_elapsed=$(get_time_elapsed "$start" | tail -n 1)
     done
     echo "Instance $instance_id is not running after $seconds_to_wait seconds"
     printf "\n"
@@ -132,20 +132,19 @@ get_latest_successful_ci_sha () {
     local latest_ci_run
     local image_sha
 
-    latest_ci_run=$(curl -fsSL -H "Accept: application/vnd.github+json" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/hanchiang/market-data-notification/actions/runs\?branch=master\&status=completed\&per_page=100 | jq '[.workflow_runs[] | select(.name | ascii_downcase | contains("test and build")) | select(.conclusion == "success")][0]')
-    if [ "$?" -ne 0 ]
+    if ! latest_ci_run=$(curl -fsSL -H "Accept: application/vnd.github+json" -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/hanchiang/market-data-notification/actions/runs?branch=master&status=completed&per_page=100" | jq '[.workflow_runs[] | select(.name | ascii_downcase | contains("test and build")) | select(.conclusion == "success")][0]')
     then
         return 1
     fi
 
-    image_sha=$(echo $latest_ci_run | jq -r '.head_sha')
+    image_sha=$(echo "$latest_ci_run" | jq -r '.head_sha')
     if [ -z "$image_sha" ] || [ "$image_sha" = "null" ]
     then
         echo "Could not determine latest successful master CI SHA"
         return 1
     fi
 
-    echo $image_sha
+    echo "$image_sha"
 }
 
 
@@ -171,7 +170,7 @@ done
 sleep 10
 
 # Configure EC2
-../ansible/start.sh $SSH_USER $SSH_PRIVATE_KEY_PATH 
+../ansible/start.sh "$SSH_USER" "$SSH_PRIVATE_KEY_PATH"
 
 # Re-run deploy workflow
 deploy_image_sha=$(get_latest_successful_ci_sha | tail -n 1)
@@ -180,11 +179,11 @@ then
     echo "No deploy image SHA resolved from CI"
     exit 1
 fi
-deploy_workflow=$(curl -fsSL -H "Accept: application/vnd.github+json" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/hanchiang/market-data-notification/actions/workflows | jq '.workflows[] | select(.state == "active" and select(.name | ascii_downcase | contains("build and deploy")))')
+deploy_workflow=$(curl -fsSL -H "Accept: application/vnd.github+json" -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/hanchiang/market-data-notification/actions/workflows" | jq '.workflows[] | select(.state == "active" and select(.name | ascii_downcase | contains("build and deploy")))')
 printf "\n"
 
-workflow_id=$(echo $deploy_workflow | jq -r .id)
-curl -fsSL -X POST  -H "Accept: application/vnd.github+json" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/hanchiang/market-data-notification/actions/workflows/$workflow_id/dispatches \
+workflow_id=$(echo "$deploy_workflow" | jq -r '.id')
+curl -fsSL -X POST  -H "Accept: application/vnd.github+json" -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/hanchiang/market-data-notification/actions/workflows/$workflow_id/dispatches" \
  -d "{\"ref\":\"master\",\"inputs\":{\"image_sha\":\"$deploy_image_sha\",\"allow_unverified_image\":\"true\"}}"
 printf "\n"
 

--- a/instances/scripts/stop.sh
+++ b/instances/scripts/stop.sh
@@ -2,22 +2,46 @@
 
 set -eu
 
-dir=$(dirname $0)
-cd $dir
+# Stop the EC2 instance and remove the public Route53 record for the service domain.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+START_ENV_FILE=${START_ENV_FILE:-"$SCRIPT_DIR/start.local.env"}
 
-source ./helper/ec2-helper.sh
+if [ -f "$START_ENV_FILE" ]
+then
+    # shellcheck disable=SC1090
+    source "$START_ENV_FILE"
+fi
+
+DOMAIN=${DOMAIN:-}
+ROUTE53_HOSTED_ZONE_ID=${ROUTE53_HOSTED_ZONE_ID:-}
+
+source "$SCRIPT_DIR/helper/ec2-helper.sh"
+
+if [ -z "$DOMAIN" ]
+then
+    echo "Missing required environment variable: DOMAIN" >&2
+    exit 1
+fi
+
+if [ -z "$ROUTE53_HOSTED_ZONE_ID" ]
+then
+    echo "Missing required environment variable: ROUTE53_HOSTED_ZONE_ID" >&2
+    exit 1
+fi
+
+export ROUTE53_HOSTED_ZONE_ID
 
 instance_info=$(get_instance_info)
-instance_state=$(echo $instance_info | jq -r '.state')
-instance_ip_address=$(echo $instance_info | jq -r '.ip_address')
-instance_id=$(echo $instance_info | jq -r .'id')
+instance_state=$(echo "$instance_info" | jq -r '.state')
+instance_id=$(echo "$instance_info" | jq -r '.id')
 
 if [ "$instance_state" = "running" ]
 then
-    DOMAINS=("api.marketdata.yaphc.com")
+    DOMAINS=("$DOMAIN")
     for domain in "${DOMAINS[@]}"
     do
-        ./route53/update-ec2-route53.sh "$domain" "DELETE"
+        "$SCRIPT_DIR/route53/update-ec2-route53.sh" "$domain" "DELETE"
     done
     
     echo "Stopping ec2 $instance_id"

--- a/instances/terraform.tfvars.example
+++ b/instances/terraform.tfvars.example
@@ -1,0 +1,5 @@
+# Copy this file to terraform.tfvars for local Terraform runs.
+
+ssh_private_key_path = "/absolute/path/to/private_key"
+ssh_public_key_path  = "/absolute/path/to/public_key.pub"
+ssh_user             = "your-ssh-user"

--- a/instances/variables.tf
+++ b/instances/variables.tf
@@ -2,40 +2,41 @@ variable "cidr_vpc" {
   description = "CIDR block for the VPC"
   default     = "10.2.0.0/16"
 }
+
 variable "cidr_subnet" {
   description = "CIDR block for the subnet"
   default     = "10.2.0.0/24"
 }
-variable "region"{
+
+variable "region" {
   description = "The region Terraform deploys your instance"
-  default = "us-east-1"
+  default     = "us-east-1"
 }
 
 variable "ec2_instance_type" {
   description = "Instance type"
-  default = "t4g.small"
+  default     = "t4g.small"
 }
 
 variable "ec2_az" {
   description = "Availability zone"
-  default = "us-east-1a"
+  default     = "us-east-1a"
 }
 
 variable "ssh_private_key_path" {
   description = "Private SSH key for EC2"
-  type = string
-  sensitive = true
+  type        = string
+  sensitive   = true
 }
 
 variable "ssh_public_key_path" {
   description = "Public SSH key for EC2"
-  type = string
+  type        = string
 }
 
 variable "ssh_user" {
   type = string
 }
-
 
 data "aws_ami" "ec2_ami" {
   name_regex  = "^market_data_notification_t4g_small$"
@@ -52,5 +53,3 @@ data "aws_ami" "ec2_ami" {
     values = ["hvm"]
   }
 }
-
-


### PR DESCRIPTION
## What changed
- add the phase-1 Let's Encrypt backup flow in infra, including the S3 bucket, lifecycle retention, IAM wiring, Ansible playbooks, and encrypted host backup script
- keep TLS reconciliation fatal while treating backup hook setup as a non-blocking follow-up during startup
- harden the local operator path for `instances/scripts/start.sh`, including generated Ansible inputs, clearer local config examples, inventory/plugin fixes, and Route53 idempotent update behavior
- add operator helpers for backup recovery validation:
  - `instances/scripts/download_letsencrypt_backup.sh`
  - `instances/scripts/run_ansible_reconciliation.sh`
- extend the infra runbook with backup verification, decryption, Linux-safe extraction guidance, and restore rehearsal steps
- ignore downloaded backup artifacts and private age keys so operator material is not staged accidentally

## Why it changed
The current host TLS state is not durable across instance replacement, so the infra repo needed an off-host recovery path that preserves private key material without emailing it or pushing backend notification work into phase 1. Once the backup path existed, the operator workflow and restore guidance also needed to be explicit enough to validate recovery without Route53 or deploy side effects.

## Impact
This branch introduces a private S3-backed, public-key-encrypted backup path for the Let's Encrypt state, plus the operator tooling and runbook needed to download, decrypt, and rehearse restore safely. The older AMI-time compatibility path remains in place until restore validation is exercised intentionally.

## Root cause
The existing deployment flow relied on host-local Let's Encrypt state plus an older AMI-time copy path, which is not sufficient disaster recovery for an instance whose root volume is deleted on termination.

## Validation
- `git diff --check origin/master...HEAD`
- `terraform fmt -check instances`
- `ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ansible-playbook --syntax-check -i localhost, instances/ansible/playbooks/letsencrypt-backup.yml`
- `bash -n instances/ansible/start.sh`
- `bash -n instances/ansible/files/letsencrypt_backup_to_s3.sh`
- `bash -n instances/scripts/start.sh instances/scripts/run_ansible_reconciliation.sh instances/scripts/download_letsencrypt_backup.sh`
- `shellcheck -x --source-path=SCRIPTDIR instances/scripts/start.sh instances/scripts/run_ansible_reconciliation.sh instances/scripts/download_letsencrypt_backup.sh`
- fixture-backed archive verification of `instances/ansible/files/letsencrypt_backup_to_s3.sh`, including the expected `accounts/`, `live/`, `archive/`, and `renewal/` contents and a negative-path missing-cert failure
- Linux extraction check of a downloaded backup archive to confirm the preserved `live/<domain>` symlinks into `archive/<domain>`
