### PR TITLE
Fix start workflow inventory hostvars

### DIFF
--- a/.github/workflows/start_market_data_notification.yml
+++ b/.github/workflows/start_market_data_notification.yml
@@ -178,7 +178,7 @@ jobs:
           regions:
             - $AWS_REGION
           groups:
-            market_data_notification: ec2_tags.Name == '$INSTANCE_TAG_NAME'
+            market_data_notification: aws_ec2_tags.Name == '$INSTANCE_TAG_NAME'
           include_filters:
             - tag:Name:
                 - $INSTANCE_TAG_NAME

--- a/instances/scripts/run_ansible_reconciliation.sh
+++ b/instances/scripts/run_ansible_reconciliation.sh
@@ -92,7 +92,7 @@ hostvars_prefix: aws_
 regions:
   - $AWS_REGION
 groups:
-  market_data_notification: ec2_tags.Name == '$INSTANCE_TAG_NAME'
+  market_data_notification: aws_ec2_tags.Name == '$INSTANCE_TAG_NAME'
 include_filters:
   - tag:Name:
       - $INSTANCE_TAG_NAME

--- a/instances/scripts/start.sh
+++ b/instances/scripts/start.sh
@@ -111,7 +111,7 @@ hostvars_prefix: aws_
 regions:
   - $AWS_REGION
 groups:
-  market_data_notification: ec2_tags.Name == '$INSTANCE_TAG_NAME'
+  market_data_notification: aws_ec2_tags.Name == '$INSTANCE_TAG_NAME'
 include_filters:
   - tag:Name:
       - $INSTANCE_TAG_NAME


### PR DESCRIPTION
## Summary
- fix the start workflow and local inventory generators to use the actual prefixed hostvar name in the dynamic inventory group expression
- restore creation of the market_data_notification inventory group after the earlier hostvars_prefix cleanup
- keep the change narrow to the inventory host-matching logic only

## Root cause
- the amazon.aws.aws_ec2 plugin creates ec2_tags and then applies hostvars_prefix before evaluating groups
- with hostvars_prefix: aws_, the group expression must use aws_ec2_tags, not ec2_tags
- the previous merged change used ec2_tags in groups, so no hosts matched market_data_notification

## Validation
- bash -n instances/scripts/start.sh instances/scripts/run_ansible_reconciliation.sh
- python3 YAML parse of .github/workflows/start_market_data_notification.yml
- git diff --check
