### PR TITLE
Harden Let's Encrypt start inventory targeting

### DIFF
--- a/.github/workflows/start_market_data_notification.yml
+++ b/.github/workflows/start_market_data_notification.yml
@@ -130,70 +130,20 @@ jobs:
       LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY: ${{ vars.LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
       HOST_NAME: ${{ secrets.HOST_NAME }}
-      INSTANCE_TAG_NAME: ${{ vars.INSTANCE_TAG_NAME }}
       ROUTE53_HOSTED_ZONE_ID: ${{ vars.ROUTE53_HOSTED_ZONE_ID }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up ansible
-        env:
-          AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
         run: |
           pwd
           ls -la
 
-          # Install ansible and required dependencie          
+          # Install ansible and required dependencies used by instances/scripts/start.sh.
           python3 -m pip install ansible boto3
           
           python3 --version
           python3 -m pip -V
           ansible --version
-
-          # Ansible config
-          sudo mkdir -p /etc/ansible
-          cat << EOF | sudo tee /etc/ansible/ansible.cfg > /dev/null
-          # Since Ansible 2.12 (core):
-          # To generate an example config file (a "disabled" one with all default settings, commented out):
-          #               $ ansible-config init --disabled > ansible.cfg
-          #
-          # Also you can now have a more complete file by including existing plugins:
-          # ansible-config init --disabled -t all > ansible.cfg
-
-          # For previous versions of Ansible you can check for examples in the 'stable' branches of each version
-          # Note that this file was always incomplete  and lagging changes to configuration settings
-
-          # for example, for 2.9: https://github.com/ansible/ansible/blob/stable-2.9/examples/ansible.cfg
-          [inventory]
-          enable_plugins = host_list, script, auto, yaml, ini, toml, amazon.aws.aws_ec2
-
-          [defaults]
-          host_key_checking = False
-          local_tmp = /tmp/ansible-local
-          EOF
-
-          # create aws-ec2.yml inventory
-          cat << EOF > ./instances/ansible/aws_ec2.yml
-          plugin: amazon.aws.aws_ec2
-          hostvars_prefix: aws_
-          regions:
-            - $AWS_REGION
-          groups:
-            market_data_notification: aws_ec2_tags.Name == '$INSTANCE_TAG_NAME'
-          include_filters:
-            - tag:Name:
-                - $INSTANCE_TAG_NAME
-          EOF
-
-          # Create variables
-          cat << EOF > ./instances/ansible/vars.yml
-          USER: $SSH_USER
-          DOMAIN: $DOMAIN
-          DOMAINS:
-            - $DOMAIN
-          ADMIN_EMAIL: $ADMIN_EMAIL
-          ansible_python_interpreter: /usr/bin/python3
-          LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY: "$LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY"
-          EOF
       - name: Create AWS config and credentials
         env:
           AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}

--- a/instances/README.md
+++ b/instances/README.md
@@ -112,7 +112,7 @@ scripts/start.sh <github token> <ssh user> <path to ssh private key>
   - `ADMIN_EMAIL` required
   - `AWS_REGION` required
   - `DOMAIN` required
-  - `INSTANCE_TAG_NAME` required
+  - `INSTANCE_TAG_NAME` optional override; defaults to the Terraform-managed EC2 `Name` tag `market_data_notification`
   - `ROUTE53_HOSTED_ZONE_ID` required
   - `LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY` optional, enables the backup hook when set
 - The local script generates temporary `instances/ansible/ansible.cfg`, `aws_ec2.yml`, and `vars.yml` files before Ansible runs, then removes them on exit.

--- a/instances/ansible/playbooks/letsencrypt-backup.yml
+++ b/instances/ansible/playbooks/letsencrypt-backup.yml
@@ -1,4 +1,4 @@
-- hosts: market_data_notification
+- hosts: all
   name: Install Let's Encrypt backup flow
   remote_user: "{{ USER }}"
   gather_facts: no

--- a/instances/ansible/playbooks/nginx-https.yml
+++ b/instances/ansible/playbooks/nginx-https.yml
@@ -1,4 +1,4 @@
-- hosts: market_data_notification
+- hosts: all
   name: Install SSL for nginx, configure nginx
   remote_user: "{{ USER }}"
   gather_facts: no

--- a/instances/scripts/README.md
+++ b/instances/scripts/README.md
@@ -27,7 +27,7 @@ scripts/start.sh <github token> <ssh user> <path to ssh private key>
   - `ADMIN_EMAIL` required
   - `AWS_REGION` required
   - `DOMAIN` required
-  - `INSTANCE_TAG_NAME` required
+  - `INSTANCE_TAG_NAME` optional override; defaults to the Terraform-managed EC2 `Name` tag `market_data_notification`
   - `ROUTE53_HOSTED_ZONE_ID` required
   - `LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY` optional
 - Local prerequisites:

--- a/instances/scripts/helper/ec2-helper.sh
+++ b/instances/scripts/helper/ec2-helper.sh
@@ -5,5 +5,5 @@ set -e
 # Get info of the instance that is most recently launched
 get_instance_info () {
     instance_info=$(aws ec2 describe-instances --filters "Name=tag:Name,Values=market_data_notification" --query 'Reservations[].Instances[].{ip_address:PublicIpAddress,state:State.Name,id:InstanceId,launch_time:LaunchTime,tags:Tags}' --output json | jq '[sort_by(.launch_time) | reverse[]][0]')
-    echo $instance_info
+    echo "$instance_info"
 }

--- a/instances/scripts/run_ansible_reconciliation.sh
+++ b/instances/scripts/run_ansible_reconciliation.sh
@@ -14,6 +14,7 @@ cd "$SCRIPT_DIR"
 
 SSH_USER=${1:-}
 SSH_PRIVATE_KEY_PATH=${2:-}
+DEFAULT_INSTANCE_TAG_NAME=market_data_notification
 ANSIBLE_DIR="$(cd ../ansible && pwd)"
 ANSIBLE_LOCAL_TEMP_DIR=${ANSIBLE_LOCAL_TEMP:-/tmp/ansible-local}
 ANSIBLE_CONFIG_PATH="$ANSIBLE_DIR/ansible.cfg"
@@ -31,7 +32,7 @@ AWS_REGION=${AWS_REGION:-}
 DOMAIN=${DOMAIN:-}
 ADMIN_EMAIL=${ADMIN_EMAIL:-}
 LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY=${LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY:-}
-INSTANCE_TAG_NAME=${INSTANCE_TAG_NAME:-}
+INSTANCE_TAG_NAME=${INSTANCE_TAG_NAME:-$DEFAULT_INSTANCE_TAG_NAME}
 
 usage() {
     echo "usage: <path/to/script> <ssh user> <ssh private key path>" >&2
@@ -67,7 +68,6 @@ require_cmd ansible-doc
 require_env ADMIN_EMAIL "$ADMIN_EMAIL"
 require_env AWS_REGION "$AWS_REGION"
 require_env DOMAIN "$DOMAIN"
-require_env INSTANCE_TAG_NAME "$INSTANCE_TAG_NAME"
 
 mkdir -p "$ANSIBLE_LOCAL_TEMP_DIR"
 
@@ -91,8 +91,6 @@ plugin: amazon.aws.aws_ec2
 hostvars_prefix: aws_
 regions:
   - $AWS_REGION
-groups:
-  market_data_notification: aws_ec2_tags.Name == '$INSTANCE_TAG_NAME'
 include_filters:
   - tag:Name:
       - $INSTANCE_TAG_NAME

--- a/instances/scripts/start.local.env.example
+++ b/instances/scripts/start.local.env.example
@@ -9,8 +9,8 @@ AWS_REGION=your-region
 # Required. Set the TLS domain to reconcile.
 DOMAIN=your.domain.example
 
-# Required. Set the EC2 Name tag used by the inventory filter.
-INSTANCE_TAG_NAME=your-instance-tag
+# Optional override. Defaults to the Terraform-managed EC2 Name tag.
+# INSTANCE_TAG_NAME=market_data_notification
 
 # Required. Set the Route53 hosted zone ID for DNS updates.
 ROUTE53_HOSTED_ZONE_ID=your-hosted-zone-id

--- a/instances/scripts/start.sh
+++ b/instances/scripts/start.sh
@@ -19,6 +19,7 @@ source "$SCRIPT_DIR/helper/timer.sh"
 GITHUB_TOKEN=${1:-}
 SSH_USER=${2:-}
 SSH_PRIVATE_KEY_PATH=${3:-}
+DEFAULT_INSTANCE_TAG_NAME=market_data_notification
 ANSIBLE_DIR="$(cd ../ansible && pwd)"
 ANSIBLE_LOCAL_TEMP_DIR=${ANSIBLE_LOCAL_TEMP:-/tmp/ansible-local}
 ANSIBLE_CONFIG_PATH="$ANSIBLE_DIR/ansible.cfg"
@@ -36,7 +37,7 @@ AWS_REGION=${AWS_REGION:-}
 DOMAIN=${DOMAIN:-}
 ADMIN_EMAIL=${ADMIN_EMAIL:-}
 LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY=${LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY:-}
-INSTANCE_TAG_NAME=${INSTANCE_TAG_NAME:-}
+INSTANCE_TAG_NAME=${INSTANCE_TAG_NAME:-$DEFAULT_INSTANCE_TAG_NAME}
 ROUTE53_HOSTED_ZONE_ID=${ROUTE53_HOSTED_ZONE_ID:-}
 
 usage () {
@@ -83,7 +84,6 @@ require_cmd ansible-doc
 require_env ADMIN_EMAIL "$ADMIN_EMAIL"
 require_env AWS_REGION "$AWS_REGION"
 require_env DOMAIN "$DOMAIN"
-require_env INSTANCE_TAG_NAME "$INSTANCE_TAG_NAME"
 require_env ROUTE53_HOSTED_ZONE_ID "$ROUTE53_HOSTED_ZONE_ID"
 
 export ROUTE53_HOSTED_ZONE_ID
@@ -110,8 +110,6 @@ plugin: amazon.aws.aws_ec2
 hostvars_prefix: aws_
 regions:
   - $AWS_REGION
-groups:
-  market_data_notification: aws_ec2_tags.Name == '$INSTANCE_TAG_NAME'
 include_filters:
   - tag:Name:
       - $INSTANCE_TAG_NAME


### PR DESCRIPTION
## Summary
- remove the fragile synthetic Ansible group from the generated EC2 inventory
- target the filtered inventory directly from the TLS and Let's Encrypt backup playbooks
- default INSTANCE_TAG_NAME to the Terraform-managed market_data_notification tag and remove duplicate workflow-side inventory generation

## Validation
- bash -n instances/scripts/start.sh instances/scripts/run_ansible_reconciliation.sh instances/ansible/start.sh instances/scripts/helper/ec2-helper.sh instances/scripts/helper/wait_for_route53_change.sh instances/scripts/helper/timer.sh
- shellcheck -e SC1091 instances/scripts/start.sh instances/scripts/run_ansible_reconciliation.sh instances/ansible/start.sh
- YAML parse check for .github/workflows/start_market_data_notification.yml and both touched Ansible playbooks
- temporary local ansible-playbook --syntax-check and --list-hosts runs confirmed both playbooks now resolve hosts via hosts: all

## Notes
- live AWS-backed inventory resolution and a full start workflow run were not executed in this session