### PR TITLE
Skip certbot dry run when cert already exists

### DIFF
--- a/instances/README.md
+++ b/instances/README.md
@@ -138,6 +138,7 @@ scripts/stop.sh
 - The actual backup upload is triggered by successful certificate issuance or renewal, not by every start run.
   - first issuance seeds a backup immediately after successful `certbot --nginx`
   - later renewals use the certbot deploy hook
+- The normal startup path does not run `certbot renew --dry-run` on every start when the certificate already exists. Renewal rehearsal stays coupled to first-time issuance rather than routine startup.
 - Treat direct playbook execution as a debugging or change-validation path, not the default operator workflow.
 
 ## Let's Encrypt Backup Rollout Checklist

--- a/instances/ansible/playbooks/nginx-https.yml
+++ b/instances/ansible/playbooks/nginx-https.yml
@@ -7,7 +7,6 @@
   vars:
     letsencrypt_backup_enabled: "{{ (LETSENCRYPT_BACKUP_AGE_PUBLIC_KEY | default('', true) | string | trim | length) > 0 }}"
     certbot_renew_cli: /usr/bin/certbot --quiet renew
-    certbot_renew_cron_line: "0 12-23 * * * {{ certbot_renew_cli }}"
   tasks:
     - name: Install required packages for SSL
       args:
@@ -57,10 +56,11 @@
           {% if letsencrypt_backup_enabled %}
           /usr/local/sbin/letsencrypt_backup_to_s3.sh
           {% endif %}
+
+          {{ certbot_renew_cli }} --dry-run
         fi
 
         sudo systemctl force-reload nginx
-        {{ certbot_renew_cli }} --dry-run
     - debug:
         var: item.stdout_lines
       loop: "{{ install_ssl.results }}"


### PR DESCRIPTION
## Summary
- stop running certbot renewal dry-run during routine startup when certificate files already exist
- keep the dry-run only in the first-time issuance path after certbot creates a new certificate
- update the infra README to reflect that startup should stay fast when TLS is already in place

## Why
The previous startup flow always ran `certbot renew --dry-run` after the cert existence check, so startup remained slow even when the log showed `SSL certs already exist`.

## Validation
- ansible-playbook --syntax-check for `instances/ansible/playbooks/nginx-https.yml` with a temporary local inventory
- ansible-playbook --list-tasks for the same playbook to confirm the extra dry-run task is gone
- git diff --check